### PR TITLE
실습 유틸리티 - domutil

### DIFF
--- a/__test__/domutil.test.js
+++ b/__test__/domutil.test.js
@@ -139,55 +139,6 @@ describe.only('이벤트 바인딩 (공통)', () => {
   });
 });
 
-describe('이벤트 바인딩 (DOM Level 0)', () => {
-  test('이벤트 바인딩 검사 (onevent)', () => {
-    document.addEventListener = null;
-    document.attachEvent = null;
-
-    domutil.on(element, eventType, mockFn);
-    element.dispatchEvent(clickEvent);
-
-    expect(mockFn).toHaveBeenCalledTimes(1);
-  });
-
-  test('이벤트 핸들러 2개 이상 추가 (onevent)', () => {
-    const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
-    document.addEventListener = null;
-    document.attachEvent = null;
-
-    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
-    element.dispatchEvent(clickEvent);
-
-    expect(mockFnArr[1]).toHaveBeenCalledBefore(mockFnArr[2]);
-    expect(mockFnArr[0]).toHaveBeenCalledBefore(mockFnArr[1]);
-  });
-
-  test('이벤트 바인딩 제거 검사 (null 할당)', () => {
-    document.addEventListener = null;
-    document.attachEvent = null;
-    document.removeEventListener = null;
-    document.detachEvent = null;
-    domutil.on(element, eventType, mockFn);
-
-    domutil.off(element, eventType, mockFn);
-    element.dispatchEvent(clickEvent);
-
-    expect(mockFn).toHaveBeenCalledTimes(0);
-  });
-
-  test('이벤트 핸들러 2개 이상 제거 (null 할당)', () => {
-    const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
-    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
-
-    domutil.off(element, eventType, mockFnArr[1]);
-    element.dispatchEvent(clickEvent);
-
-    expect(mockFnArr[0]).toHaveBeenCalledTimes(1);
-    expect(mockFnArr[1]).toHaveBeenCalledTimes(0);
-    expect(mockFnArr[2]).toHaveBeenCalledTimes(1);
-  });
-});
-
 describe('이벤트 바인딩 (DOM Level 2)', () => {
   test('이벤트 바인딩 검사 (addEventListener)', () => {
     domutil.on(element, eventType, mockFn);
@@ -223,50 +174,5 @@ describe('이벤트 바인딩 (DOM Level 2)', () => {
     element.dispatchEvent(clickEvent);
 
     mockFnArr.forEach((f, i) => expect(f).toBeCalledTimes(i === 1 ? 0 : 1));
-  });
-});
-
-describe('이벤트 바인딩 (<IE9)', () => {
-  test('이벤트 바인딩 검사 (attachEvent)', () => {
-    document.attachEvent = document.addEventListener;
-    document.addEventListener = null;
-
-    domutil.on(element, eventType, mockFn);
-    element.dispatchEvent(clickEvent);
-
-    expect(mockFn).toHaveBeenCalledTimes(1);
-  });
-
-  test('이벤트 핸들러 2개 이상 추가 (attachEvent)', () => {
-    const mockFnArr = [jest.fn(() => 0), jest.fn(() => 1), jest.fn(() => 2)];
-    document.attachEvent = document.addEventListener;
-    document.addEventListener = null;
-
-    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
-    element.dispatchEvent(clickEvent);
-
-    expect(mockFnArr[2]).toHaveBeenCalledBefore(mockFnArr[1]);
-    expect(mockFnArr[1]).toHaveBeenCalledBefore(mockFnArr[0]);
-  });
-
-  test('이벤트 바인딩 제거 검사 (detachEvent)', () => {
-    document.attachEvent = document.addEventListener;
-    document.addEventListener = null;
-    document.detachEvent = document.removeEventListener;
-    document.removeEventListener = null;
-    domutil.on(element, eventType, mockFn);
-
-    domutil.off(element, eventType, mockFn);
-    element.dispatchEvent(clickEvent);
-
-    expect(mockFn).toHaveBeenCalledTimes(0);
-  });
-
-  test('이벤트 핸들러 2개 이상 제거 (detachEvent)', () => {
-    // const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
-    // mockFnArr.forEach((f) => domutil.on(element, eventType, f));
-    // domutil.off(element, eventType, mockFnArr[1]);
-    // element.dispatchEvent(clickEvent);
-    // mockFnArr.forEach((f, i) => expect(f).toBeCalledTimes(i === 1 ? 0 : 1));
   });
 });

--- a/__test__/domutil.test.js
+++ b/__test__/domutil.test.js
@@ -4,7 +4,6 @@ import helper from '@/lib/helper';
 const eventType = 'click';
 let mockFn = jest.fn();
 let element;
-let invalidElement;
 let clickEvent;
 function getMockFnReturnValue(fn, index) {
   return fn.mock.results[index].value;
@@ -13,13 +12,13 @@ function getMockFnReturnValue(fn, index) {
 beforeAll(() => {
   document.body.innerHTML = `<div id="foo"></div>`;
   element = document.getElementById('foo');
-  invalidElement = document.getElementById('bar');
 
   clickEvent = new Event(eventType, {bubbles: true});
 });
 
 afterEach(() => {
   mockFn.mockReset();
+  domutil.removeAll(element, eventType);
 });
 
 describe('요소 접근', () => {
@@ -60,8 +59,8 @@ describe('요소 접근', () => {
   });
 });
 
-describe.only('이벤트 바인딩 (공통)', () => {
-  test.only('유효하지 않은 요소로 이벤트 바인딩 시도하는 경우', () => {
+describe('이벤트 바인딩 (공통)', () => {
+  test('유효하지 않은 요소로 이벤트 바인딩 시도하는 경우', () => {
     // given
     const selectorEmptyString = '';
     const selectorNull = null;
@@ -141,38 +140,51 @@ describe.only('이벤트 바인딩 (공통)', () => {
 
 describe('이벤트 바인딩 (DOM Level 2)', () => {
   test('이벤트 바인딩 검사 (addEventListener)', () => {
+    // when
     domutil.on(element, eventType, mockFn);
     element.dispatchEvent(clickEvent);
 
+    // then
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
   test('이벤트 핸들러 2개 이상 추가 (addEventListener)', () => {
+    // given
     const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
-    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
 
+    // when
+    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
     element.dispatchEvent(clickEvent);
 
-    expect(mockFnArr[1]).toHaveBeenCalledBefore(mockFnArr[2]);
+    // then
     expect(mockFnArr[0]).toHaveBeenCalledBefore(mockFnArr[1]);
+    expect(mockFnArr[1]).toHaveBeenCalledBefore(mockFnArr[2]);
   });
 
   test('이벤트 바인딩 제거 검사 (removeEventListener) ', () => {
+    // given
     domutil.on(element, eventType, mockFn);
 
+    // when
     domutil.off(element, eventType, mockFn);
     element.dispatchEvent(clickEvent);
 
+    // then
     expect(mockFn).toHaveBeenCalledTimes(0);
   });
 
   test('이벤트 핸들러 2개 이상 제거 (removeEventListener)', () => {
+    // given
     const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
     mockFnArr.forEach((f) => domutil.on(element, eventType, f));
 
+    // when
     domutil.off(element, eventType, mockFnArr[1]);
     element.dispatchEvent(clickEvent);
 
-    mockFnArr.forEach((f, i) => expect(f).toBeCalledTimes(i === 1 ? 0 : 1));
+    // then
+    expect(mockFnArr[0]).toHaveBeenCalledTimes(1);
+    expect(mockFnArr[1]).toHaveBeenCalledTimes(0);
+    expect(mockFnArr[2]).toHaveBeenCalledTimes(1);
   });
 });

--- a/__test__/domutil.test.js
+++ b/__test__/domutil.test.js
@@ -1,0 +1,272 @@
+import domutil from '@/lib/domutil';
+import helper from '@/lib/helper';
+
+const eventType = 'click';
+let mockFn = jest.fn();
+let element;
+let invalidElement;
+let clickEvent;
+function getMockFnReturnValue(fn, index) {
+  return fn.mock.results[index].value;
+}
+
+beforeAll(() => {
+  document.body.innerHTML = `<div id="foo"></div>`;
+  element = document.getElementById('foo');
+  invalidElement = document.getElementById('bar');
+
+  clickEvent = new Event(eventType, {bubbles: true});
+});
+
+afterEach(() => {
+  mockFn.mockReset();
+});
+
+describe('요소 접근', () => {
+  test('selector로 요소 접근하는 경우', () => {
+    // given
+    const selectorId = element.id;
+
+    // when
+    const received = helper.getElement(`#${selectorId}`);
+
+    // then
+    expect(received).toEqual(element);
+  });
+
+  test('DOM Element로 접근 하는 경우', () => {
+    // given
+    const selectorDOM = element;
+
+    // when
+    const received = helper.getElement(selectorDOM);
+
+    // then
+    expect(received).toEqual(element);
+  });
+
+  test('유효하지 않은 값으로 요소 접근하는 경우', () => {
+    // given
+    const selectorEmptyString = '';
+    const selectorNull = null;
+
+    // when
+    const throwErrorFn1 = () => helper.getElement(selectorEmptyString);
+    const throwErrorFn2 = () => helper.getElement(selectorNull);
+
+    // then
+    expect(throwErrorFn1).toThrow();
+    expect(throwErrorFn2).toThrow();
+  });
+});
+
+describe.only('이벤트 바인딩 (공통)', () => {
+  test.only('유효하지 않은 요소로 이벤트 바인딩 시도하는 경우', () => {
+    // given
+    const selectorEmptyString = '';
+    const selectorNull = null;
+
+    // when
+    const throwErrorFn1 = () => domutil.on(selectorEmptyString, eventType, () => {});
+    const throwErrorFn2 = () => domutil.on(selectorNull, eventType, () => {});
+
+    // then
+    expect(throwErrorFn1).toThrow();
+    expect(throwErrorFn2).toThrow();
+  });
+
+  test('유효하지 않은 이벤트 타입으로 이벤트 바인딩 시도하는 경우', () => {
+    // given
+    const eventTypeEmptyString = '';
+    const eventTypeNull = null;
+
+    // when
+    const throwErrorFn1 = () => domutil.on(element, eventTypeEmptyString, () => {});
+    const throwErrorFn2 = () => domutil.on(element, eventTypeNull, () => {});
+
+    // then
+    expect(throwErrorFn1).toThrow();
+    expect(throwErrorFn2).toThrow();
+  });
+
+  test('유효하지 않은 함수로 이벤트 바인딩 시도하는 경우', () => {
+    // given
+    const handlerEmptyString = '';
+    const handlerNull = null;
+
+    // when
+    const throwErrorFn1 = () => domutil.on(element, eventType, handlerEmptyString);
+    const throwErrorFn2 = () => domutil.on(element, eventType, handlerNull);
+
+    // then
+    expect(throwErrorFn1).toThrow();
+    expect(throwErrorFn2).toThrow();
+  });
+
+  test('이벤트 핸들러 내부의 this value 검사', () => {
+    // given
+    mockFn.mockReturnThis();
+
+    // when
+    domutil.on(element, eventType, mockFn);
+    element.dispatchEvent(clickEvent);
+
+    // then
+    expect(getMockFnReturnValue(mockFn, 0)).toEqual(element);
+  });
+
+  test('이벤트가 버블링 된 경우의 currentTarget과 target 값 검사', () => {
+    // given
+    element.innerHTML = `<div id="current"></div>`;
+    const bubblingTarget = element;
+    const target = document.getElementById('current');
+    mockFn.mockImplementation((e) => ({
+      currentTarget: e.currentTarget,
+      target: e.target
+    }));
+
+    // when
+    domutil.on(target, eventType, mockFn);
+    domutil.on(bubblingTarget, eventType, mockFn);
+    target.dispatchEvent(clickEvent);
+
+    // then
+    expect(mockFn).toHaveBeenCalledTimes(2);
+    expect(getMockFnReturnValue(mockFn, 1).currentTarget).toEqual(bubblingTarget);
+    expect(getMockFnReturnValue(mockFn, 1).target).toEqual(target);
+
+    document.body.innerHTML = `<div class="foo"></div>`;
+  });
+});
+
+describe('이벤트 바인딩 (DOM Level 0)', () => {
+  test('이벤트 바인딩 검사 (onevent)', () => {
+    document.addEventListener = null;
+    document.attachEvent = null;
+
+    domutil.on(element, eventType, mockFn);
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('이벤트 핸들러 2개 이상 추가 (onevent)', () => {
+    const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
+    document.addEventListener = null;
+    document.attachEvent = null;
+
+    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFnArr[1]).toHaveBeenCalledBefore(mockFnArr[2]);
+    expect(mockFnArr[0]).toHaveBeenCalledBefore(mockFnArr[1]);
+  });
+
+  test('이벤트 바인딩 제거 검사 (null 할당)', () => {
+    document.addEventListener = null;
+    document.attachEvent = null;
+    document.removeEventListener = null;
+    document.detachEvent = null;
+    domutil.on(element, eventType, mockFn);
+
+    domutil.off(element, eventType, mockFn);
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
+  });
+
+  test('이벤트 핸들러 2개 이상 제거 (null 할당)', () => {
+    const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
+    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
+
+    domutil.off(element, eventType, mockFnArr[1]);
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFnArr[0]).toHaveBeenCalledTimes(1);
+    expect(mockFnArr[1]).toHaveBeenCalledTimes(0);
+    expect(mockFnArr[2]).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('이벤트 바인딩 (DOM Level 2)', () => {
+  test('이벤트 바인딩 검사 (addEventListener)', () => {
+    domutil.on(element, eventType, mockFn);
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('이벤트 핸들러 2개 이상 추가 (addEventListener)', () => {
+    const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
+    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
+
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFnArr[1]).toHaveBeenCalledBefore(mockFnArr[2]);
+    expect(mockFnArr[0]).toHaveBeenCalledBefore(mockFnArr[1]);
+  });
+
+  test('이벤트 바인딩 제거 검사 (removeEventListener) ', () => {
+    domutil.on(element, eventType, mockFn);
+
+    domutil.off(element, eventType, mockFn);
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
+  });
+
+  test('이벤트 핸들러 2개 이상 제거 (removeEventListener)', () => {
+    const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
+    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
+
+    domutil.off(element, eventType, mockFnArr[1]);
+    element.dispatchEvent(clickEvent);
+
+    mockFnArr.forEach((f, i) => expect(f).toBeCalledTimes(i === 1 ? 0 : 1));
+  });
+});
+
+describe('이벤트 바인딩 (<IE9)', () => {
+  test('이벤트 바인딩 검사 (attachEvent)', () => {
+    document.attachEvent = document.addEventListener;
+    document.addEventListener = null;
+
+    domutil.on(element, eventType, mockFn);
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('이벤트 핸들러 2개 이상 추가 (attachEvent)', () => {
+    const mockFnArr = [jest.fn(() => 0), jest.fn(() => 1), jest.fn(() => 2)];
+    document.attachEvent = document.addEventListener;
+    document.addEventListener = null;
+
+    mockFnArr.forEach((f) => domutil.on(element, eventType, f));
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFnArr[2]).toHaveBeenCalledBefore(mockFnArr[1]);
+    expect(mockFnArr[1]).toHaveBeenCalledBefore(mockFnArr[0]);
+  });
+
+  test('이벤트 바인딩 제거 검사 (detachEvent)', () => {
+    document.attachEvent = document.addEventListener;
+    document.addEventListener = null;
+    document.detachEvent = document.removeEventListener;
+    document.removeEventListener = null;
+    domutil.on(element, eventType, mockFn);
+
+    domutil.off(element, eventType, mockFn);
+    element.dispatchEvent(clickEvent);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
+  });
+
+  test('이벤트 핸들러 2개 이상 제거 (detachEvent)', () => {
+    // const mockFnArr = [jest.fn(), jest.fn(), jest.fn()];
+    // mockFnArr.forEach((f) => domutil.on(element, eventType, f));
+    // domutil.off(element, eventType, mockFnArr[1]);
+    // element.dispatchEvent(clickEvent);
+    // mockFnArr.forEach((f, i) => expect(f).toBeCalledTimes(i === 1 ? 0 : 1));
+  });
+});

--- a/__test__/domutil.test.js
+++ b/__test__/domutil.test.js
@@ -1,5 +1,4 @@
-import domutil from '@/lib/domutil';
-import helper from '@/lib/helper';
+import * as domutil from '@/lib/domutil';
 
 const eventType = 'click';
 let mockFn = jest.fn();
@@ -19,44 +18,6 @@ beforeAll(() => {
 afterEach(() => {
   mockFn.mockReset();
   domutil.removeAll(element, eventType);
-});
-
-describe('요소 접근', () => {
-  test('selector로 요소 접근하는 경우', () => {
-    // given
-    const selectorId = element.id;
-
-    // when
-    const received = helper.getElement(`#${selectorId}`);
-
-    // then
-    expect(received).toEqual(element);
-  });
-
-  test('DOM Element로 접근 하는 경우', () => {
-    // given
-    const selectorDOM = element;
-
-    // when
-    const received = helper.getElement(selectorDOM);
-
-    // then
-    expect(received).toEqual(element);
-  });
-
-  test('유효하지 않은 값으로 요소 접근하는 경우', () => {
-    // given
-    const selectorEmptyString = '';
-    const selectorNull = null;
-
-    // when
-    const throwErrorFn1 = () => helper.getElement(selectorEmptyString);
-    const throwErrorFn2 = () => helper.getElement(selectorNull);
-
-    // then
-    expect(throwErrorFn1).toThrow();
-    expect(throwErrorFn2).toThrow();
-  });
 });
 
 describe('이벤트 바인딩 (공통)', () => {

--- a/__test__/helper.test.js
+++ b/__test__/helper.test.js
@@ -1,0 +1,44 @@
+import * as helper from '@/lib/helper';
+
+describe('getElement', () => {
+  let element;
+  beforeAll(() => {
+    document.body.innerHTML = `<div id="foo"></div>`;
+    element = document.getElementById('foo');
+  });
+  test('selector로 요소 접근하는 경우', () => {
+    // given
+    const selectorId = element.id;
+
+    // when
+    const received = helper.getElement(`#${selectorId}`);
+
+    // then
+    expect(received).toEqual(element);
+  });
+
+  test('DOM Element로 접근 하는 경우', () => {
+    // given
+    const selectorDOM = element;
+
+    // when
+    const received = helper.getElement(selectorDOM);
+
+    // then
+    expect(received).toEqual(element);
+  });
+
+  test('유효하지 않은 값으로 요소 접근하는 경우', () => {
+    // given
+    const selectorEmptyString = '';
+    const selectorNull = null;
+
+    // when
+    const throwErrorFn1 = () => helper.getElement(selectorEmptyString);
+    const throwErrorFn2 = () => helper.getElement(selectorNull);
+
+    // then
+    expect(throwErrorFn1).toThrow();
+    expect(throwErrorFn2).toThrow();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -7287,6 +7287,241 @@
         "jest-util": "^26.6.1"
       }
     },
+    "jest-extended": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-0.11.5.tgz",
+      "integrity": "sha512-3RsdFpLWKScpsLD6hJuyr/tV5iFOrw7v6YjA3tPdda9sJwoHwcMROws5gwiIZfcwhHlJRwFJB2OUvGmF3evV/Q==",
+      "dev": true,
+      "requires": {
+        "expect": "^24.1.0",
+        "jest-get-type": "^22.4.3",
+        "jest-matcher-utils": "^22.0.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+          "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+          "dev": true,
+          "requires": {
+            "@jest/source-map": "^24.9.0",
+            "chalk": "^2.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+          "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.1.15",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+          "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/istanbul-lib-coverage": "^2.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+          "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+          "dev": true
+        },
+        "@types/yargs": {
+          "version": "13.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+          "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+          "dev": true
+        },
+        "expect": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+          "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-styles": "^3.2.0",
+            "jest-get-type": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-regex-util": "^24.9.0"
+          },
+          "dependencies": {
+            "jest-get-type": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+              "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+              "dev": true
+            },
+            "jest-matcher-utils": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+              "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.0.1",
+                "jest-diff": "^24.9.0",
+                "jest-get-type": "^24.9.0",
+                "pretty-format": "^24.9.0"
+              }
+            }
+          }
+        },
+        "jest-diff": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+          "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff-sequences": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          },
+          "dependencies": {
+            "jest-get-type": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+              "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+              "dev": true
+            }
+          }
+        },
+        "jest-get-type": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+          "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+          "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "pretty-format": {
+              "version": "22.4.3",
+              "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+              "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0",
+                "ansi-styles": "^3.2.0"
+              }
+            }
+          }
+        },
+        "jest-message-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+          "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^2.0.1",
+            "micromatch": "^3.1.10",
+            "slash": "^2.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-regex-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+          "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "stack-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+          "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+          "dev": true
+        }
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "testRegex": "\\.test\\.js$",
     "moduleNameMapper": {
       "@/(.*)$": "<rootDir>/src/$1"
-    }
+    },
+    "setupFilesAfterEnv": ["jest-extended"]
   },
   "author": "",
   "license": "ISC",
@@ -42,6 +43,7 @@
     "eslint-webpack-plugin": "^2.1.0",
     "html-webpack-plugin": "^4.5.0",
     "jest": "^26.6.1",
+    "jest-extended": "^0.11.5",
     "mini-css-extract-plugin": "^1.2.1",
     "prettier": "^2.1.2",
     "sass": "^1.28.0",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,0 @@
-import sayHello from '@js/sayHello';
-import styleSCSS from '@styles/sample';
-
-if (module.hot) {
-  module.hot.accept();
-}
-console.log(sayHello());

--- a/src/js/sayHello.js
+++ b/src/js/sayHello.js
@@ -1,3 +1,0 @@
-export default function sayHello() {
-  return 'Hello!';
-}

--- a/src/js/sum.js
+++ b/src/js/sum.js
@@ -1,3 +1,0 @@
-export default function sum(a, b) {
-  return a + b;
-}

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -13,6 +13,7 @@ const domutil = (function () {
     // on
     if (document.addEventListener) {
       addEvent = function (type, handler) {
+        listeners.push(handler);
         element.addEventListener(type, handler);
       };
     } else if (document.attachEvent) {

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -30,6 +30,7 @@ const domutil = (function () {
       };
     } else {
       addEvent = function (type, handler) {
+        handler = handler.bind(element);
         listeners.push(handler);
         element[`on${type}`] = (e) => listeners.forEach((fn) => fn(e));
       };

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -1,0 +1,75 @@
+import helper from '@/lib/helper';
+
+document.addEventListener = null;
+document.removeEventListener = null;
+
+const domutil = (function () {
+  let addEvent = null;
+  let removeEvent = null;
+  let element = null;
+  let listeners = [];
+
+  (function () {
+    // on
+    if (document.addEventListener) {
+      addEvent = function (type, handler) {
+        element.addEventListener(type, handler);
+      };
+    } else if (document.attachEvent) {
+      addEvent = function (type, handler) {
+        handler = handler.bind(element);
+
+        let reverseListeners = listeners.slice().reverse();
+        reverseListeners.forEach((fn) => element.removeEventListener(type, fn));
+
+        listeners.push(handler);
+        reverseListeners.unshift(handler);
+
+        reverseListeners.forEach((fn) => element.attachEvent(type, fn));
+      };
+    } else {
+      addEvent = function (type, handler) {
+        listeners.push(handler);
+        element[`on${type}`] = () => listeners.forEach((fn) => fn());
+      };
+    }
+
+    // off
+    if (document.removeEventListener) {
+      removeEvent = function (type, handler) {
+        element.removeEventListener(type, handler);
+      };
+    } else if (document.detachEvent) {
+      removeEvent = function (type, handler) {
+        element.detachEvent(type, handler);
+      };
+    } else {
+      removeEvent = function (type, handler) {
+        listeners = listeners.filter((fn) => fn !== handler);
+        element[`on${type}`] = () => listeners.forEach((fn) => fn());
+      };
+    }
+  })();
+
+  const on = (selector, type, handler) => {
+    element = helper.getElement(selector);
+    helper.checkType(type);
+    helper.checkHandler(handler);
+    addEvent(type, handler);
+  };
+  const off = (selector, type, handler) => {
+    element = helper.getElement(selector);
+    helper.checkType(type);
+    helper.checkHandler(handler);
+    removeEvent(type, handler);
+  };
+  return {
+    on(selector, type, handler) {
+      on(selector, type, handler);
+    },
+    off(selector, type, handler) {
+      off(selector, type, handler);
+    }
+  };
+})();
+export default domutil;

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -62,13 +62,21 @@ const domutil = (function () {
     helper.checkType(type);
     helper.checkHandler(handler);
     removeEvent(type, handler);
-  };
+  }
+  function removeAll(selector, type) {
+    element = helper.getElement(selector);
+    helper.checkType(type);
+    listeners.forEach((fn) => removeEvent(type, fn));
+  }
   return {
     on(selector, type, handler) {
       on(selector, type, handler);
     },
     off(selector, type, handler) {
       off(selector, type, handler);
+    },
+    removeAll(selector, type) {
+      removeAll(selector, type);
     }
   };
 })();

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -49,28 +49,28 @@ let listeners = []; // TODO: 초기화, 요소-타입별 관리
   }
 })();
 
-export function on(selector, type, handler) {
+export const on = (selector, type, handler) => {
   element = getElement(selector);
 
   if (!isString(type) || isEmptyString(type)) throw Error('올바른 이벤트 타입이 필요합니다.');
   if (!isFunction(handler)) throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');
 
   addEvent(type, handler);
-}
+};
 
-export function off(selector, type, handler) {
+export const off = (selector, type, handler) => {
   element = getElement(selector);
 
   if (!isString(type) || isEmptyString(type)) throw Error('올바른 이벤트 타입이 필요합니다.');
   if (!isFunction(handler)) throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');
 
   removeEvent(type, handler);
-}
+};
 
-export function removeAll(selector, type) {
+export const removeAll = (selector, type) => {
   element = getElement(selector);
 
   if (!isString(type) || isEmptyString(type)) throw Error('올바른 이벤트 타입이 필요합니다.');
 
   listeners.forEach((fn) => removeEvent(type, fn));
-}
+};

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -30,7 +30,7 @@ const domutil = (function () {
     } else {
       addEvent = function (type, handler) {
         listeners.push(handler);
-        element[`on${type}`] = () => listeners.forEach((fn) => fn());
+        element[`on${type}`] = (e) => listeners.forEach((fn) => fn(e));
       };
     }
 
@@ -46,7 +46,7 @@ const domutil = (function () {
     } else {
       removeEvent = function (type, handler) {
         listeners = listeners.filter((fn) => fn !== handler);
-        element[`on${type}`] = () => listeners.forEach((fn) => fn());
+        element[`on${type}`] = (e) => listeners.forEach((fn) => fn(e));
       };
     }
   })();

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -1,82 +1,76 @@
-import helper from '@/lib/helper';
+import {getElement, isString, isEmptyString, isFunction} from '@/lib/helper';
 
-const domutil = (function () {
-  let addEvent = null;
-  let removeEvent = null;
-  let element = null;
-  let listeners = [];
+let addEvent = null;
+let removeEvent = null;
+let element = null; // TODO: 초기화
+let listeners = []; // TODO: 초기화, 요소-타입별 관리
 
-  (function () {
-    // on
-    if (document.addEventListener) {
-      addEvent = function (type, handler) {
-        listeners.push(handler);
-        element.addEventListener(type, handler);
-      };
-    } else if (document.attachEvent) {
-      addEvent = function (type, handler) {
-        handler = handler.bind(element);
+(function () {
+  // on
+  if (document.addEventListener) {
+    addEvent = function (type, handler) {
+      listeners.push(handler);
+      element.addEventListener(type, handler);
+    };
+  } else if (document.attachEvent) {
+    addEvent = function (type, handler) {
+      handler = handler.bind(element);
 
-        let reverseListeners = listeners.slice().reverse();
-        reverseListeners.forEach((fn) => element.removeEventListener(type, fn));
+      const reverseListeners = listeners.slice().reverse();
+      reverseListeners.forEach((fn) => element.detachEvent(type, fn));
 
-        listeners.push(handler);
-        reverseListeners.unshift(handler);
+      listeners.push(handler);
+      reverseListeners.unshift(handler);
 
-        reverseListeners.forEach((fn) => element.attachEvent(type, fn));
-      };
-    } else {
-      addEvent = function (type, handler) {
-        handler = handler.bind(element);
-        listeners.push(handler);
-        element[`on${type}`] = (e) => listeners.forEach((fn) => fn(e));
-      };
-    }
-
-    // off
-    if (document.removeEventListener) {
-      removeEvent = function (type, handler) {
-        element.removeEventListener(type, handler);
-      };
-    } else if (document.detachEvent) {
-      removeEvent = function (type, handler) {
-        element.detachEvent(type, handler);
-      };
-    } else {
-      removeEvent = function (type, handler) {
-        listeners = listeners.filter((fn) => fn !== handler);
-        element[`on${type}`] = (e) => listeners.forEach((fn) => fn(e));
-      };
-    }
-  })();
-
-  function on(selector, type, handler) {
-    element = helper.getElement(selector);
-    helper.checkType(type);
-    helper.checkHandler(handler);
-    addEvent(type, handler);
+      reverseListeners.forEach((fn) => element.attachEvent(type, fn));
+    };
+  } else {
+    addEvent = function (type, handler) {
+      handler = handler.bind(element);
+      listeners.push(handler);
+      element[`on${type}`] = (e) => listeners.forEach((fn) => fn(e));
+    };
   }
-  function off(selector, type, handler) {
-    element = helper.getElement(selector);
-    helper.checkType(type);
-    helper.checkHandler(handler);
-    removeEvent(type, handler);
+
+  // off
+  if (document.removeEventListener) {
+    removeEvent = function (type, handler) {
+      element.removeEventListener(type, handler);
+    };
+  } else if (document.detachEvent) {
+    removeEvent = function (type, handler) {
+      element.detachEvent(type, handler);
+    };
+  } else {
+    removeEvent = function (type, handler) {
+      listeners = listeners.filter((fn) => fn !== handler);
+      element[`on${type}`] = (e) => listeners.forEach((fn) => fn(e));
+    };
   }
-  function removeAll(selector, type) {
-    element = helper.getElement(selector);
-    helper.checkType(type);
-    listeners.forEach((fn) => removeEvent(type, fn));
-  }
-  return {
-    on(selector, type, handler) {
-      on(selector, type, handler);
-    },
-    off(selector, type, handler) {
-      off(selector, type, handler);
-    },
-    removeAll(selector, type) {
-      removeAll(selector, type);
-    }
-  };
 })();
-export default domutil;
+
+export function on(selector, type, handler) {
+  element = getElement(selector);
+
+  if (!isString(type) || isEmptyString(type)) throw Error('올바른 이벤트 타입이 필요합니다.');
+  if (!isFunction(handler)) throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');
+
+  addEvent(type, handler);
+}
+
+export function off(selector, type, handler) {
+  element = getElement(selector);
+
+  if (!isString(type) || isEmptyString(type)) throw Error('올바른 이벤트 타입이 필요합니다.');
+  if (!isFunction(handler)) throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');
+
+  removeEvent(type, handler);
+}
+
+export function removeAll(selector, type) {
+  element = getElement(selector);
+
+  if (!isString(type) || isEmptyString(type)) throw Error('올바른 이벤트 타입이 필요합니다.');
+
+  listeners.forEach((fn) => removeEvent(type, fn));
+}

--- a/src/lib/domutil.js
+++ b/src/lib/domutil.js
@@ -1,8 +1,5 @@
 import helper from '@/lib/helper';
 
-document.addEventListener = null;
-document.removeEventListener = null;
-
 const domutil = (function () {
   let addEvent = null;
   let removeEvent = null;
@@ -53,13 +50,13 @@ const domutil = (function () {
     }
   })();
 
-  const on = (selector, type, handler) => {
+  function on(selector, type, handler) {
     element = helper.getElement(selector);
     helper.checkType(type);
     helper.checkHandler(handler);
     addEvent(type, handler);
-  };
-  const off = (selector, type, handler) => {
+  }
+  function off(selector, type, handler) {
     element = helper.getElement(selector);
     helper.checkType(type);
     helper.checkHandler(handler);

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -1,32 +1,17 @@
-export function getElement(selector) {
+export const getElement = (selector) => {
   let element = null;
 
   if (isString(selector)) {
     element = document.querySelector(selector);
-  } else if (isElement(selector)) {
+  } else if (isElement(selector) || isWindow(selector)) {
     element = selector;
   }
   if (isNull(element)) throw Error('요소가 존재하지 않습니다.');
 
   return element;
-}
-
-export function isElement(v) {
-  return v instanceof Element;
-}
-
-export function isString(v) {
-  return typeof v === 'string';
-}
-
-export function isEmptyString(v) {
-  return v === '';
-}
-
-export function isFunction(v) {
-  return typeof v === 'function';
-}
-
-export function isNull(v) {
-  return v === null;
-}
+};
+export const isElement = (v) => v instanceof Element;
+export const isString = (v) => typeof v === 'string';
+export const isEmptyString = (v) => v === '';
+export const isFunction = (v) => typeof v === 'function';
+export const isNull = (v) => v === null;

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -1,0 +1,34 @@
+const helper = (function () {
+  const getElement = (selector) => {
+    let element = null;
+
+    if (typeof selector === 'string') {
+      element = document.querySelector(selector);
+    } else if (selector instanceof Element) {
+      element = selector;
+    }
+    if (element === null) throw Error('요소가 존재하지 않습니다.');
+
+    return element;
+  };
+
+  const checkType = (type) => {
+    if (typeof type !== 'string' && type !== '') throw Error('올바른 이벤트 타입이 필요합니다.');
+  };
+  const checkHandler = (handler) => {
+    if (typeof handler !== 'function') throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');
+  };
+
+  return {
+    getElement(selector) {
+      return getElement(selector);
+    },
+    checkType(type) {
+      checkType(type);
+    },
+    checkHandler(handler) {
+      checkHandler(handler);
+    }
+  };
+})();
+export default helper;

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -13,7 +13,7 @@ const helper = (function () {
   };
 
   const checkType = (type) => {
-    if (typeof type !== 'string' && type !== '') throw Error('올바른 이벤트 타입이 필요합니다.');
+    if (typeof type !== 'string' || type === '') throw Error('올바른 이벤트 타입이 필요합니다.');
   };
   const checkHandler = (handler) => {
     if (typeof handler !== 'function') throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -1,36 +1,32 @@
-const helper = (function () {
-  function getElement(selector) {
-    let element = null;
+export function getElement(selector) {
+  let element = null;
 
-    if (typeof selector === 'string') {
-      element = document.querySelector(selector);
-    } else if (selector instanceof Element) {
-      element = selector;
-    }
-    if (element === null) throw Error('요소가 존재하지 않습니다.');
-
-    return element;
+  if (isString(selector)) {
+    element = document.querySelector(selector);
+  } else if (isElement(selector)) {
+    element = selector;
   }
+  if (isNull(element)) throw Error('요소가 존재하지 않습니다.');
 
-  function checkType(type) {
-    if (typeof type !== 'string' || type === '') throw Error('올바른 이벤트 타입이 필요합니다.');
-  }
+  return element;
+}
 
-  function checkHandler(handler) {
-    if (typeof handler !== 'function') throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');
-  }
+export function isElement(v) {
+  return v instanceof Element;
+}
 
-  return {
-    getElement(selector) {
-      return getElement(selector);
-    },
-    checkType(type) {
-      checkType(type);
-    },
-    checkHandler(handler) {
-      checkHandler(handler);
-    }
-  };
-})();
+export function isString(v) {
+  return typeof v === 'string';
+}
 
-export default helper;
+export function isEmptyString(v) {
+  return v === '';
+}
+
+export function isFunction(v) {
+  return typeof v === 'function';
+}
+
+export function isNull(v) {
+  return v === null;
+}

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -1,5 +1,5 @@
 const helper = (function () {
-  const getElement = (selector) => {
+  function getElement(selector) {
     let element = null;
 
     if (typeof selector === 'string') {
@@ -10,14 +10,15 @@ const helper = (function () {
     if (element === null) throw Error('요소가 존재하지 않습니다.');
 
     return element;
-  };
+  }
 
-  const checkType = (type) => {
+  function checkType(type) {
     if (typeof type !== 'string' || type === '') throw Error('올바른 이벤트 타입이 필요합니다.');
-  };
-  const checkHandler = (handler) => {
+  }
+
+  function checkHandler(handler) {
     if (typeof handler !== 'function') throw Error('올바른 이벤트 핸들러 함수가 필요합니다.');
-  };
+  }
 
   return {
     getElement(selector) {
@@ -31,4 +32,5 @@ const helper = (function () {
     }
   };
 })();
+
 export default helper;


### PR DESCRIPTION
## domutil 


- 구현 사항
  - 크로스 브라우징 대응
    - attachEvent/detachEvent
      - 핸들러 함수 내부에서 가리키는 this, event 객체 bind
      - 핸들러 함수 2개 이상 등록 시 등록한 순서의 반대로 call 되는 동작 대응
    - onevent 
      - 핸들러 내부에서 가리키는 this, event 객체 bind 
      - 핸들러 함수 2개 이상 등록 시 이전에 등록한 핸들러 함수를 덮어씌우는 동작 대응
  - parameter 유효성 검사
    - selector/type/handler
  - TC 구현

- 미구현 사항
  - 요소와 event type 별 핸들러 리스트 관리
  - removeEventListener/detachEvent 시 핸들러 리스트에서도 제거되야하는 기능 (현재 onevent 만 구현되어있음)



