### PR TITLE
실습 과제 - defineClass

### DIFF
--- a/__test__/defineClass.test.js
+++ b/__test__/defineClass.test.js
@@ -1,79 +1,178 @@
 import util from '@/lib/util';
 
-let obj = null;
-let objWithInit = null;
-
-beforeAll(() => {
-  obj = {
-    sum: function (a, b) {
-      return a + b;
-    }
-  };
-  objWithInit = {
-    init: function (a, b) {
-      this.a = a;
-      this.b = b;
-    },
-    sum: function () {
-      return this.a + this.b;
-    }
-  };
-});
+const Sub = {
+  sum: function (a, b) {
+    return a + b;
+  }
+};
+const SubWithInit = {
+  init: function (a, b) {
+    this.a = a;
+    this.b = b;
+  },
+  sum: function () {
+    return this.a + this.b;
+  }
+};
+const Super = {
+  sum: function (a, b, c) {
+    return a + b + c;
+  },
+  multi: function (a, b, c) {
+    return a * b * c;
+  }
+};
+const SuperWithInit = {
+  init: function () {
+    this.c = 10;
+  },
+  sum: function () {
+    return this.a + this.b + this.c;
+  },
+  multi: function () {
+    return this.a * this.b * this.c;
+  }
+};
 
 describe('인스턴스 생성', () => {
   test('생성자 함수 검사', () => {
     // given
-    const Sum = util.defineClass(obj);
+    const SubClass = util.defineClass(Sub);
 
     // when
-    const instance = new Sum();
+    const instance = new SubClass();
 
     // then
-    expect(Sum.prototype.constructor).toEqual(Sum);
-    expect(instance.constructor).toEqual(Sum);
+    expect(SubClass.prototype.constructor).toEqual(SubClass);
+    expect(instance.constructor).toEqual(SubClass);
   });
 
   test('메서드 검사', () => {
     // given
-    const Sum = util.defineClass(obj);
+    const SubClass = util.defineClass(Sub);
 
     // when
-    const instance = new Sum();
+    const instance = new SubClass();
 
     // then
     expect(instance.sum(1, 2)).toBe(3);
   });
 
-  test('init 있는 경우', () => {
-    // given
-    const Sum = util.defineClass(objWithInit);
-
-    // when
-    const instance = new Sum(1, 2);
-
-    // then
-    expect(Sum.prototype.constructor).toEqual(objWithInit.init);
-    expect(instance.sum()).toBe(3);
-  });
-
   test('인스턴스가 여러개인 경우', () => {
     // given
-    const Sum = util.defineClass(objWithInit);
+    const SubClass = util.defineClass(SubWithInit);
 
     // when
-    const instance1 = new Sum(1, 2);
-    const instance2 = new Sum(1, 2);
+    const instance1 = new SubClass(1, 2);
+    const instance2 = new SubClass(1, 2);
 
     // then
     expect(instance1.sum === instance2.sum).toBeTruthy();
     expect(instance1 === instance2).toBeFalsy();
   });
+
+  describe('매개변수를 전달하는 init 있는 경우', () => {
+    test('instance type 검사', () => {
+      // given
+      const SubClass = util.defineClass(SubWithInit);
+
+      // when
+      const instance = new SubClass(1, 3);
+
+      // then
+      expect(instance instanceof SubWithInit.init).toBeTruthy();
+    });
+
+    test('멤버 변수 검사', () => {
+      // given
+      const SubClass = util.defineClass(SubWithInit);
+
+      // when
+      const instance = new SubClass(1, 3);
+
+      // then
+      expect(instance.a).toBe(1);
+      expect(instance.b).toBe(3);
+    });
+  });
 });
 
-describe('부모 상속 인스턴스 생성', () => {
-  test('인스턴스 ', () => {
+describe('부모 클래스를 상속한 인스턴스 생성', () => {
+  test('생성자 함수 검사', () => {
     // given
+    const SubClass = util.defineClass(Sub, Super);
+
     // when
+    const instance = new SubClass();
+
     // then
+    expect(SubClass.prototype.constructor).toEqual(SubClass);
+    expect(instance.constructor).toEqual(SubClass);
+  });
+
+  test('메서드 오버라이딩 검사', () => {
+    // given
+    const SubClass = util.defineClass(Sub, Super);
+
+    // when
+    const instance = new SubClass();
+
+    // then
+    expect(instance.sum(1, 3, 5)).toBe(4); // 1 + 3
+    expect(instance.sum(1, 3, 5)).not.toBe(9); // 1 + 3 + 5
+    expect(instance.multi(1, 3, 5)).toBe(15); // 1 * 3 * 5
+  });
+
+  test('인스턴스가 여러개인 경우', () => {
+    // given
+    const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+
+    // when
+    const instance1 = new SubClass(1, 2);
+    const instance2 = new SubClass(1, 2);
+
+    // then
+    expect(instance1.sum === instance2.sum).toBeTruthy();
+    expect(instance1.multi === instance2.multi).toBeTruthy();
+    expect(instance1 === instance2).toBeFalsy();
+  });
+
+  describe('매개변수를 전달하는 init 있는 경우', () => {
+    test('instance type 검사', () => {
+      // given;
+      const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+
+      // when
+      const instance = new SubClass(1, 3);
+
+      // then
+      expect(instance instanceof SubWithInit.init).toBeTruthy();
+      expect(instance instanceof SuperWithInit.init).toBeTruthy();
+    });
+
+    test('멤버 변수 검사', () => {
+      // given;
+      const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+
+      // when
+      const instance = new SubClass(1, 3);
+
+      // then
+      expect(instance.a).toBe(1);
+      expect(instance.b).toBe(3);
+      expect(instance.c).toBe(10);
+    });
+
+    test('메소드 오버라이딩 검사', () => {
+      // given;
+      const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+
+      // when
+      const instance = new SubClass(1, 3);
+
+      // then
+      expect(instance.sum()).toBe(4); // 1 + 3
+      expect(instance.multi()).toBe(30); // 1 * 3 * 10
+    });
   });
 });

--- a/__test__/defineClass.test.js
+++ b/__test__/defineClass.test.js
@@ -1,11 +1,11 @@
 import util from '@/lib/util';
 
-const Sub = {
+const Child = {
   sum: function (a, b) {
     return a + b;
   }
 };
-const SubWithInit = {
+const ChildWithInit = {
   init: function (a, b) {
     this.a = a;
     this.b = b;
@@ -14,7 +14,7 @@ const SubWithInit = {
     return this.a + this.b;
   }
 };
-const Super = {
+const Parent = {
   sum: function (a, b, c) {
     return a + b + c;
   },
@@ -22,7 +22,7 @@ const Super = {
     return a * b * c;
   }
 };
-const SuperWithInit = {
+const ParentWithInit = {
   init: function () {
     this.c = 10;
   },
@@ -37,22 +37,22 @@ const SuperWithInit = {
 describe('인스턴스 생성', () => {
   test('생성자 함수 검사', () => {
     // given
-    const SubClass = util.defineClass(Sub);
+    const ChildClass = util.defineClass(Child);
 
     // when
-    const instance = new SubClass();
+    const instance = new ChildClass();
 
     // then
-    expect(SubClass.prototype.constructor).toEqual(SubClass);
-    expect(instance.constructor).toEqual(SubClass);
+    expect(ChildClass.prototype.constructor).toEqual(ChildClass);
+    expect(instance.constructor).toEqual(ChildClass);
   });
 
   test('메서드 검사', () => {
     // given
-    const SubClass = util.defineClass(Sub);
+    const ChildClass = util.defineClass(Child);
 
     // when
-    const instance = new SubClass();
+    const instance = new ChildClass();
 
     // then
     expect(instance.sum(1, 2)).toBe(3);
@@ -60,11 +60,11 @@ describe('인스턴스 생성', () => {
 
   test('인스턴스가 여러개인 경우', () => {
     // given
-    const SubClass = util.defineClass(SubWithInit);
+    const ChildClass = util.defineClass(ChildWithInit);
 
     // when
-    const instance1 = new SubClass(1, 2);
-    const instance2 = new SubClass(1, 2);
+    const instance1 = new ChildClass(1, 2);
+    const instance2 = new ChildClass(1, 2);
 
     // then
     expect(instance1.sum === instance2.sum).toBeTruthy();
@@ -74,21 +74,21 @@ describe('인스턴스 생성', () => {
   describe('매개변수를 전달하는 init 있는 경우', () => {
     test('instance type 검사', () => {
       // given
-      const SubClass = util.defineClass(SubWithInit);
+      const ChildClass = util.defineClass(ChildWithInit);
 
       // when
-      const instance = new SubClass(1, 3);
+      const instance = new ChildClass(1, 3);
 
       // then
-      expect(instance instanceof SubWithInit.init).toBeTruthy();
+      expect(instance instanceof ChildWithInit.init).toBeTruthy();
     });
 
     test('멤버 변수 검사', () => {
       // given
-      const SubClass = util.defineClass(SubWithInit);
+      const ChildClass = util.defineClass(ChildWithInit);
 
       // when
-      const instance = new SubClass(1, 3);
+      const instance = new ChildClass(1, 3);
 
       // then
       expect(instance.a).toBe(1);
@@ -100,22 +100,22 @@ describe('인스턴스 생성', () => {
 describe('부모 클래스를 상속한 인스턴스 생성', () => {
   test('생성자 함수 검사', () => {
     // given
-    const SubClass = util.defineClass(Sub, Super);
+    const ChildClass = util.defineClass(Child, Parent);
 
     // when
-    const instance = new SubClass();
+    const instance = new ChildClass();
 
     // then
-    expect(SubClass.prototype.constructor).toEqual(SubClass);
-    expect(instance.constructor).toEqual(SubClass);
+    expect(ChildClass.prototype.constructor).toEqual(ChildClass);
+    expect(instance.constructor).toEqual(ChildClass);
   });
 
   test('메서드 오버라이딩 검사', () => {
     // given
-    const SubClass = util.defineClass(Sub, Super);
+    const ChildClass = util.defineClass(Child, Parent);
 
     // when
-    const instance = new SubClass();
+    const instance = new ChildClass();
 
     // then
     expect(instance.sum(1, 3, 5)).toBe(4); // 1 + 3
@@ -125,11 +125,11 @@ describe('부모 클래스를 상속한 인스턴스 생성', () => {
 
   test('인스턴스가 여러개인 경우', () => {
     // given
-    const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+    const ChildClass = util.defineClass(ChildWithInit, ParentWithInit);
 
     // when
-    const instance1 = new SubClass(1, 2);
-    const instance2 = new SubClass(1, 2);
+    const instance1 = new ChildClass(1, 2);
+    const instance2 = new ChildClass(1, 2);
 
     // then
     expect(instance1.sum === instance2.sum).toBeTruthy();
@@ -140,22 +140,22 @@ describe('부모 클래스를 상속한 인스턴스 생성', () => {
   describe('매개변수를 전달하는 init 있는 경우', () => {
     test('instance type 검사', () => {
       // given;
-      const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+      const ChildClass = util.defineClass(ChildWithInit, ParentWithInit);
 
       // when
-      const instance = new SubClass(1, 3);
+      const instance = new ChildClass(1, 3);
 
       // then
-      expect(instance instanceof SubWithInit.init).toBeTruthy();
-      expect(instance instanceof SuperWithInit.init).toBeTruthy();
+      expect(instance instanceof ChildWithInit.init).toBeTruthy();
+      expect(instance instanceof ParentWithInit.init).toBeTruthy();
     });
 
     test('멤버 변수 검사', () => {
       // given;
-      const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+      const ChildClass = util.defineClass(ChildWithInit, ParentWithInit);
 
       // when
-      const instance = new SubClass(1, 3);
+      const instance = new ChildClass(1, 3);
 
       // then
       expect(instance.a).toBe(1);
@@ -165,10 +165,10 @@ describe('부모 클래스를 상속한 인스턴스 생성', () => {
 
     test('메소드 오버라이딩 검사', () => {
       // given;
-      const SubClass = util.defineClass(SubWithInit, SuperWithInit);
+      const ChildClass = util.defineClass(ChildWithInit, ParentWithInit);
 
       // when
-      const instance = new SubClass(1, 3);
+      const instance = new ChildClass(1, 3);
 
       // then
       expect(instance.sum()).toBe(4); // 1 + 3

--- a/__test__/defineClass.test.js
+++ b/__test__/defineClass.test.js
@@ -1,0 +1,79 @@
+import util from '@/lib/util';
+
+let obj = null;
+let objWithInit = null;
+
+beforeAll(() => {
+  obj = {
+    sum: function (a, b) {
+      return a + b;
+    }
+  };
+  objWithInit = {
+    init: function (a, b) {
+      this.a = a;
+      this.b = b;
+    },
+    sum: function () {
+      return this.a + this.b;
+    }
+  };
+});
+
+describe('인스턴스 생성', () => {
+  test('생성자 함수 검사', () => {
+    // given
+    const Sum = util.defineClass(obj);
+
+    // when
+    const instance = new Sum();
+
+    // then
+    expect(Sum.prototype.constructor).toEqual(Sum);
+    expect(instance.constructor).toEqual(Sum);
+  });
+
+  test('메서드 검사', () => {
+    // given
+    const Sum = util.defineClass(obj);
+
+    // when
+    const instance = new Sum();
+
+    // then
+    expect(instance.sum(1, 2)).toBe(3);
+  });
+
+  test('init 있는 경우', () => {
+    // given
+    const Sum = util.defineClass(objWithInit);
+
+    // when
+    const instance = new Sum(1, 2);
+
+    // then
+    expect(Sum.prototype.constructor).toEqual(objWithInit.init);
+    expect(instance.sum()).toBe(3);
+  });
+
+  test('인스턴스가 여러개인 경우', () => {
+    // given
+    const Sum = util.defineClass(objWithInit);
+
+    // when
+    const instance1 = new Sum(1, 2);
+    const instance2 = new Sum(1, 2);
+
+    // then
+    expect(instance1.sum === instance2.sum).toBeTruthy();
+    expect(instance1 === instance2).toBeFalsy();
+  });
+});
+
+describe('부모 상속 인스턴스 생성', () => {
+  test('인스턴스 ', () => {
+    // given
+    // when
+    // then
+  });
+});

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -14,4 +14,5 @@ export const isElement = (v) => v instanceof Element;
 export const isString = (v) => typeof v === 'string';
 export const isEmptyString = (v) => v === '';
 export const isFunction = (v) => typeof v === 'function';
+export const isObject = (v) => v.toString() === '[object Object]';
 export const isNull = (v) => v === null;

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -6,15 +6,16 @@ const util = {
       return util.makeClass(Child);
     }
 
-    // 상속
+    // inheritance
     const ParentClass = util.makeClass(Parent);
-    const _init = isFunction(Child.init) ? Child.init : null;
-    const initFunction = function (...args) {
+    const childInit = isFunction(Child.init) ? Child.init : null;
+
+    Child.init = function (...args) {
       ParentClass.apply(this);
-      if (!isNull(_init)) _init.apply(this, args);
+      if (!isNull(childInit)) childInit.apply(this, args);
     };
-    Child.init = initFunction;
     Child.init.prototype = new ParentClass();
+
     return util.makeClass(Child);
   },
   makeClass(properties) {
@@ -31,6 +32,7 @@ const util = {
 
     fakeClass.prototype.constructor = fakeClass;
     methods.forEach(([k, v]) => (fakeClass.prototype[k] = v));
+
     return fakeClass;
   }
 };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,29 +1,27 @@
-/*
-util.defineClass({ 자식 클래스 객체 }, ?SuperClass);
+import {isObject, isFunction, isNull} from '@/lib/helper';
 
-init 메서드가 존재하면 인스턴스를 생성할 때 호출되어야 한다.
-init 메서드안에서는 생성된 인스턴스를 this를 통해 접근 가능 하다.
-상속과정에서 부모의 init 메서드에서 생성되는 객체맴버는 명시적으로 자식에서 init 을 실행해야 상속 된다.
-상속과정에서 메서드는 오버라이딩이 가능하다.
-
-var Animal = util.defineClass({
-    init: function() {},
-    walk: function() {}
-});
-var Person = util.defineClass({
-    init: function() {},
-    talk: function() {}
-    // etc...
-}, Animal);
-
-var p = new Person();
-*/
 const util = {
   defineClass(Child, Parent) {
+    if (!Parent || !isObject(Parent)) {
+      return util.makeClass(Child);
+    }
+
+    // 상속
+    const ParentClass = util.makeClass(Parent);
+    const _init = isFunction(Child.init) ? Child.init : null;
+    const initFunction = function (...args) {
+      ParentClass.apply(this);
+      if (!isNull(_init)) _init.apply(this, args);
+    };
+    Child.init = initFunction;
+    Child.init.prototype = new ParentClass();
+    return util.makeClass(Child);
+  },
+  makeClass(properties) {
     const methods = [];
     let fakeClass = function () {};
 
-    Object.entries(Child).forEach(([k, v]) => {
+    Object.entries(properties).forEach(([k, v]) => {
       if (k === 'init') {
         fakeClass = v;
       } else {
@@ -33,7 +31,6 @@ const util = {
 
     fakeClass.prototype.constructor = fakeClass;
     methods.forEach(([k, v]) => (fakeClass.prototype[k] = v));
-
     return fakeClass;
   }
 };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,0 +1,41 @@
+/*
+util.defineClass({ 자식 클래스 객체 }, ?SuperClass);
+
+init 메서드가 존재하면 인스턴스를 생성할 때 호출되어야 한다.
+init 메서드안에서는 생성된 인스턴스를 this를 통해 접근 가능 하다.
+상속과정에서 부모의 init 메서드에서 생성되는 객체맴버는 명시적으로 자식에서 init 을 실행해야 상속 된다.
+상속과정에서 메서드는 오버라이딩이 가능하다.
+
+var Animal = util.defineClass({
+    init: function() {},
+    walk: function() {}
+});
+var Person = util.defineClass({
+    init: function() {},
+    talk: function() {}
+    // etc...
+}, Animal);
+
+var p = new Person();
+*/
+const util = {
+  defineClass(Child, Parent) {
+    const methods = [];
+    let fakeClass = function () {};
+
+    Object.entries(Child).forEach(([k, v]) => {
+      if (k === 'init') {
+        fakeClass = v;
+      } else {
+        methods.push([k, v]);
+      }
+    });
+
+    fakeClass.prototype.constructor = fakeClass;
+    methods.forEach(([k, v]) => (fakeClass.prototype[k] = v));
+
+    return fakeClass;
+  }
+};
+
+export default util;


### PR DESCRIPTION
- 참고
  - Parent의 init에서 parameter를 받는 경우는 고려하지 않았습니다.
  - defineClass의 parameter로 넘기는 object에 init이 포함된 경우 object의 속성 정의 순서와 상관 없이 동작하도록 구현했습니다.