### PR TITLE
실습 과제 - dnd

### DIFF
--- a/configs/webpack.base.config.js
+++ b/configs/webpack.base.config.js
@@ -3,7 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
-  entry: path.resolve(__dirname, '../src/js/index.js'),
+  entry: {index: ['babel-polyfill', path.resolve(__dirname, '../src/js/index.js')]},
   output: {
     path: path.resolve(__dirname, '../dist'),
     filename: 'app.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2826,6 +2826,25 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-current-node-syntax": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
@@ -2853,6 +2872,24 @@
       "requires": {
         "babel-plugin-jest-hoist": "^26.5.0",
         "babel-preset-current-node-syntax": "^0.1.3"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
       }
     },
     "balanced-match": {
@@ -3731,6 +3768,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/jest": "^26.0.15",
     "babel-jest": "^26.6.1",
     "babel-loader": "^8.1.0",
+    "babel-polyfill": "^6.26.0",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.0",
     "eslint": "^7.12.1",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,9 +1,16 @@
 import dnd from '@/lib/dnd';
+import * as domutil from '@/lib/domutil';
 const str = `
-    <input value="button" type="button" style=" margin-top:10px;"/>      
+    <input value="button" type="button" style=" margin-top:10px;width:50px;height:30px"/>      
     <div id="red" class="red" style="margin-top:20px;background-color: red;width:100px;height:100px;">
     </div>
 `;
 document.body.innerHTML = str;
 
 dnd.draggable('input');
+
+const dropzone = dnd.dropzone('#red');
+
+domutil.on(dropzone, 'drop', (eventData) => {
+  console.log(eventData);
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,8 +5,12 @@ const str = `
     <div class="item">1</div>   
     <div class="item">2</div>   
     <div class="item">3</div>   
-    <div class="item">4</div>   
-    <div class="list">
+    <div class="item">4</div>
+    <div style="display:flex">
+      <div class="list">
+      </div>
+      <div class="list2">
+      </div>
     </div>
 `;
 document.body.innerHTML = str;
@@ -15,7 +19,11 @@ document.body.innerHTML = str;
 document.querySelectorAll('.item').forEach((el) => dnd.draggable(el));
 
 const dropzone = dnd.dropzone('.list');
+const dropzone2 = dnd.dropzone('.list2');
 
 domutil.on(dropzone, 'drop', (eventData) => {
-  console.log('eventData : ', eventData.detail);
+  console.log('eventData(dropzone) : ', eventData.detail);
+});
+domutil.on(dropzone2, 'drop', (eventData) => {
+  console.log('eventData(dropzone2) : ', eventData.detail);
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,8 +1,9 @@
 import dnd from '@/lib/dnd';
 import * as domutil from '@/lib/domutil';
 const str = `
-    <input value="button" type="button" style=" margin-top:10px;width:50px;height:30px"/>      
+    <input value="button" type="button" style="width:50px;height:30px"/>      
     <div id="red" class="red" style="margin-top:20px;background-color: red;width:100px;height:100px;">
+        <input value="button" type="button2" style="width:50px;height:30px;background-color:yellow"/>      
     </div>
 `;
 document.body.innerHTML = str;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -17,5 +17,5 @@ document.querySelectorAll('.item').forEach((el) => dnd.draggable(el));
 const dropzone = dnd.dropzone('.list');
 
 domutil.on(dropzone, 'drop', (eventData) => {
-  console.log(eventData);
+  console.log('eventData : ', eventData.detail);
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,1 +1,9 @@
-console.log('index.js loaded');
+import dnd from '@/lib/dnd';
+const str = `
+    <input value="button" type="button" style=" margin-top:10px;"/>      
+    <div id="red" class="red" style="margin-top:20px;background-color: red;width:100px;height:100px;">
+    </div>
+`;
+document.body.innerHTML = str;
+
+dnd.draggable('input');

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,7 @@
 import dnd from '@/lib/dnd';
 import * as domutil from '@/lib/domutil';
 import '@/styles/index.scss';
+
 const str = `
     <div class="item">1</div>   
     <div class="item">2</div>   
@@ -15,7 +16,6 @@ const str = `
 `;
 document.body.innerHTML = str;
 
-// dnd.draggable('.item');
 document.querySelectorAll('.item').forEach((el) => dnd.draggable(el));
 
 const dropzone = dnd.dropzone('.list');

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,16 +1,16 @@
 import dnd from '@/lib/dnd';
 import * as domutil from '@/lib/domutil';
+import '@/styles/index.scss';
 const str = `
-    <input value="button" type="button" style="width:50px;height:30px"/>      
-    <div id="red" class="red" style="margin-top:20px;background-color: red;width:100px;height:100px;">
-        <input value="button" type="button2" style="width:50px;height:30px;background-color:yellow"/>      
+    <div class="item"></div>   
+    <div class="list">
     </div>
 `;
 document.body.innerHTML = str;
 
-dnd.draggable('input');
+dnd.draggable('.item');
 
-const dropzone = dnd.dropzone('#red');
+const dropzone = dnd.dropzone('.list');
 
 domutil.on(dropzone, 'drop', (eventData) => {
   console.log(eventData);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,4 @@
 import dnd from '@/lib/dnd';
-import * as domutil from '@/lib/domutil';
 import '@/styles/index.scss';
 
 const str = `
@@ -21,9 +20,11 @@ document.querySelectorAll('.item').forEach((el) => dnd.draggable(el));
 const dropzone = dnd.dropzone('.list');
 const dropzone2 = dnd.dropzone('.list2');
 
-domutil.on(dropzone, 'drop', (eventData) => {
-  console.log('eventData(dropzone) : ', eventData.detail);
+dropzone.on('drop', (eventData) => {
+  console.log(eventData.target); // 드롭 된 엘리먼트
+  console.log(eventData.isContain); // 완전 포함 여부
 });
-domutil.on(dropzone2, 'drop', (eventData) => {
-  console.log('eventData(dropzone2) : ', eventData.detail);
+dropzone2.on('drop', (eventData) => {
+  console.log(eventData.target); // 드롭 된 엘리먼트
+  console.log(eventData.isContain); // 완전 포함 여부
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,13 +2,17 @@ import dnd from '@/lib/dnd';
 import * as domutil from '@/lib/domutil';
 import '@/styles/index.scss';
 const str = `
-    <div class="item"></div>   
+    <div class="item">1</div>   
+    <div class="item">2</div>   
+    <div class="item">3</div>   
+    <div class="item">4</div>   
     <div class="list">
     </div>
 `;
 document.body.innerHTML = str;
 
-dnd.draggable('.item');
+// dnd.draggable('.item');
+document.querySelectorAll('.item').forEach((el) => dnd.draggable(el));
 
 const dropzone = dnd.dropzone('.list');
 

--- a/src/lib/CustomEvents.js
+++ b/src/lib/CustomEvents.js
@@ -1,5 +1,5 @@
 import ListenerHelper from '@/lib/ListenerHelper';
-import {isObject, isString, isEmptyString, isFunction} from '@/lib/helper';
+import {isObject, isString, isEmptyString, isFunction, isElement} from '@/lib/helper';
 
 const listenersHelper = new ListenerHelper();
 
@@ -26,7 +26,7 @@ const mixinOff = (obj) => (type, handler) => {
 
 const CustomEvents = {
   mixin(obj) {
-    if (!isObject(obj)) throw Error('올바른 객체가 필요합니다.');
+    if (!isElement(obj) && !isObject(obj)) throw Error('올바른 타겟이 필요합니다.');
 
     obj.on = mixinOn(obj);
     obj.fire = mixinFire(obj);

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -123,7 +123,7 @@ function setPosition(event) {
         if (len < 2) {
           child = children[i] || null;
           childRect = child && child.getBoundingClientRect();
-          if (childRect && childRect.top < top) dropzone.prepend(ghostShadow);
+          if (childRect && childRect.top > top) dropzone.prepend(ghostShadow);
           else dropzone.append(ghostShadow);
           hideGhost();
           return;

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -1,0 +1,55 @@
+import {getElement} from '@/lib/helper';
+
+let originElement = null;
+let ghost = null;
+
+export async function make(selector) {
+  originElement = getElement(selector);
+  create().then(ready);
+}
+
+async function create() {
+  ghost = originElement.cloneNode(true);
+  ghost.style.position = 'fixed';
+  ghost.style.zIndex = 1000;
+}
+
+function ready() {
+  ghost.addEventListener('mousedown', (event) => {
+    document.body.append(ghost);
+    document.addEventListener('mousemove', setPosition);
+    ghost.addEventListener('mouseup', handleMouseUp);
+  });
+}
+
+export function execute() {
+  ghost.dispatchEvent(new Event('mousedown'));
+}
+
+function finish(event) {
+  const {clientX, clientY} = event;
+  const belowElements = document.elementsFromPoint(clientX, clientY);
+  const dropzone = belowElements[1];
+  dropzone.appendChild(originElement);
+  destroy();
+}
+
+function destroy() {
+  ghost.parentNode.removeChild(ghost);
+  ghost = null;
+  originElement = null;
+}
+
+function setPosition(event) {
+  const {offsetLeft, offsetTop} = originElement;
+  const {pageX, pageY} = event;
+  ghost.style.left = `${pageX - offsetLeft}px`;
+  ghost.style.top = `${pageY - offsetTop}px`;
+}
+
+function handleMouseUp(event) {
+  document.removeEventListener('mousemove', setPosition);
+  ghost.removeEventListener('mouseup', handleMouseUp);
+
+  finish(event);
+}

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -105,49 +105,53 @@ function setPosition(event) {
     const dropzone = getDropzone(left, top);
 
     const item = getDraggableItem(left + width / 2, top + height / 2);
-
     if (isElement(item)) {
-      // draggable 요소의 앞 또는 뒤
+      // draggable 요소의 앞 또는 뒤에 추가
       insertBetweenDraggableItems(item, top);
-    } else {
-      // draggable 요소 사이에 공백이 있어서 draggable item이 안 잡히는 경우 모든 item을 확인
-      const children = dropzone.children;
-      const len = children.length;
 
-      let i = 0;
-      let child, childRect;
-      if (len < 2) {
-        child = children[i] || null;
-        childRect = child && child.getBoundingClientRect();
-        if (childRect && childRect.top > top) dropzone.prepend(ghostShadow);
-        else dropzone.append(ghostShadow);
-        hideGhost();
-        return;
-      }
-
-      let nextChild, nextChildRect;
-      for (i = 1; i < len; i++) {
-        child = children[i];
-        childRect = child.getBoundingClientRect();
-        if (childRect.top > top) {
-          dropzone.prepend(ghostShadow);
-          break;
-        }
-
-        nextChild = children[i + 1] || null;
-        nextChildRect = nextChild ? nextChild.getBoundingClientRect() : null;
-        if (!nextChildRect) {
-          dropzone.append(ghostShadow);
-          break;
-        }
-        if (childRect.bottom <= top && nextChildRect.top > top) {
-          insertNodeAfter(ghostShadow, child);
-          break;
-        }
-      }
+      // drag할 위치가 drag하려는 요소의 원래 위치가 같으면 preview(ghost) 숨김
+      hideGhost();
+      return;
     }
 
-    // drag할 위치가 drag하려는 요소의 원래 위치가 같으면 preview(ghost) 숨김
+    // draggable 요소 사이에 공백이 있어서 draggable item이 안 잡히는 경우 모든 item을 확인
+    const children = dropzone.children;
+    const len = children.length;
+
+    let child, childRect;
+    if (len < 2) {
+      child = children[0] || null;
+      childRect = child && child.getBoundingClientRect();
+
+      if (childRect && childRect.top > top) dropzone.prepend(ghostShadow);
+      else dropzone.append(ghostShadow);
+
+      hideGhost();
+      return;
+    }
+
+    let i, nextChild, nextChildRect;
+    for (i = 1; i < len; i++) {
+      child = children[i];
+
+      childRect = child.getBoundingClientRect();
+      if (childRect.top > top) {
+        dropzone.prepend(ghostShadow);
+        break;
+      }
+
+      nextChild = children[i + 1] || null;
+      if (!nextChild) {
+        dropzone.append(ghostShadow);
+        break;
+      }
+
+      nextChildRect = nextChild.getBoundingClientRect();
+      if (childRect.bottom <= top && nextChildRect.top > top) {
+        insertNodeAfter(ghostShadow, child);
+        break;
+      }
+    }
     hideGhost();
   }, 200);
 }
@@ -203,14 +207,6 @@ function getDraggableItem(x, y) {
   return draggableItem;
 }
 
-function getDropEvent() {
-  return new CustomEvent('drop', {bubbles: false, detail: {target: originElement, isContain}});
-}
-
-function isOriginElement(element) {
-  return isElement(element) && element.classList.contains('dnd-hidden-origin');
-}
-
-function clone(element) {
-  return element.cloneNode(true);
-}
+const getDropEvent = () => new CustomEvent('drop', {bubbles: false, detail: {target: originElement, isContain}});
+const isOriginElement = (element) => isElement(element) && element.classList.contains('dnd-hidden-origin');
+const clone = (element) => element.cloneNode(true);

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -101,7 +101,8 @@ function setPosition(event) {
     dropzoneTopLeft.appendChild(ghostShadow);
     ghostShadow.classList.remove('dnd-none');
   } else {
-    ghostShadow.parentNode.removeChild(ghostShadow);
+    // 한번이라도 append 된 적 있어야 parentNode가 존재
+    if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
     ghostShadow.classList.add('dnd-none');
   }
 }

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -1,4 +1,5 @@
 import {getElement, isElement} from '@/lib/helper';
+import '@/styles/dnd.ghost.scss';
 
 const ERROR_CODE = {
   E01: 'dropzone이 아닙니다.'
@@ -18,8 +19,7 @@ async function create() {
   ghost.style.position = 'fixed';
   ghost.style.zIndex = 1000;
 
-  // TODO: originElement는 흐릿하게하던가 아니면 색깔을 주던가..
-  // originElement.classList.add('dnd-hidden-origin');
+  originElement.classList.add('dnd-hidden-origin');
 }
 
 function ready() {
@@ -40,13 +40,13 @@ function finish(event) {
 
   dropzone.dispatchEvent(dropEvent);
 
-  // originElement.classList.remove('dnd-hidden-origin');
   dropzone.appendChild(originElement);
 
   destroy();
 }
 
 function destroy() {
+  originElement.classList.remove('dnd-hidden-origin');
   ghost.parentNode.removeChild(ghost);
   ghost = null;
   originElement = null;

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -10,6 +10,8 @@ let ghostShadow = null;
 let ghostWidth, ghostHeight;
 let dropzone = null;
 let isContain = false;
+let clickedLeft = 0;
+let clickedTop = 0;
 
 function getSize(element) {
   return {
@@ -25,13 +27,13 @@ function getPosition(element) {
   };
 }
 
-export async function make(selector) {
+export async function make(selector, x, y) {
   originElement = getElement(selector);
 
-  create().then(ready);
+  create(x, y).then(ready);
 }
 
-async function create() {
+async function create(x, y) {
   ghost = originElement.cloneNode(true);
   ghostShadow = originElement.cloneNode(true);
 
@@ -45,6 +47,10 @@ async function create() {
   ghostShadow.classList.add('dnd-none');
   ghostShadow.classList.add('dnd-shadow');
   originElement.classList.add('dnd-hidden-origin');
+
+  const {top, left} = getPosition(originElement);
+  clickedLeft = x - left;
+  clickedTop = y - top;
 }
 
 function ready() {
@@ -76,7 +82,7 @@ function finish(event) {
 function destroy() {
   originElement.classList.remove('dnd-hidden-origin');
   ghost.parentNode.removeChild(ghost);
-  ghostShadow.parentNode.removeChild(ghostShadow);
+  if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
 
   ghost = null;
   ghostShadow = null;
@@ -86,11 +92,9 @@ function destroy() {
 }
 
 function setPosition(event) {
-  const {offsetLeft, offsetTop} = originElement;
   const {pageX, pageY} = event;
-
-  ghost.style.left = `${pageX - offsetLeft}px`;
-  ghost.style.top = `${pageY - offsetTop}px`;
+  ghost.style.left = `${pageX - clickedLeft}px`;
+  ghost.style.top = `${pageY - clickedTop}px`;
 
   const {top, left} = getPosition(ghost);
   const dropzoneTopLeft = getDropzone(left, top);
@@ -98,6 +102,7 @@ function setPosition(event) {
   isContain = isElement(dropzoneTopLeft) && isElement(dropzoneBottomRight) && dropzoneTopLeft === dropzoneBottomRight;
 
   if (isContain) {
+    // const draggableItem = getDraggableItem(left + ghostWidth/2, top + ghostHeight/2);
     dropzoneTopLeft.appendChild(ghostShadow);
     ghostShadow.classList.remove('dnd-none');
   } else {

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -1,10 +1,9 @@
-import {getElement, isElement, isElements, insertNodeAfter, insertNodeBefore} from '@/lib/helper';
+import {getElement, isElement, isElements, insertNodeAfter, insertNodeBefore, debounce} from '@/lib/helper';
 import '@/styles/dnd.ghost.scss';
 
 const ERROR_CODE = {
   E01: 'dropzone이 아닙니다.'
 };
-let debounce = null;
 let clickedLeft = 0;
 let clickedTop = 0;
 let originElement = null;
@@ -100,8 +99,7 @@ function setPosition(event) {
     return;
   }
 
-  clearTimeout(debounce);
-  debounce = setTimeout(() => {
+  debounce(() => {
     const dropzone = getDropzone(left, top);
 
     const item = getDraggableItem(left + width / 2, top + height / 2);
@@ -153,7 +151,7 @@ function setPosition(event) {
       }
     }
     hideGhost();
-  }, 200);
+  }, 200)();
 }
 
 function hideGhost() {

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -94,65 +94,62 @@ function setPosition(event) {
   ghost.style.top = `${pageY - clickedTop}px`;
 
   const {top, left, width, height} = ghost.getBoundingClientRect();
-  const belowGhostTopLeft = getDropzone(left, top);
-  const belowGhostBottomRight = getDropzone(left + width, top + height - 5);
 
-  isContain = isElements(belowGhostTopLeft, belowGhostBottomRight) && belowGhostTopLeft === belowGhostBottomRight;
-
-  if (!isContain) {
+  if (!isConatinGhost()) {
     hideGhostShadow();
-  } else {
-    clearTimeout(debounce);
-    debounce = setTimeout(() => {
-      const dropzone = belowGhostTopLeft;
+    return;
+  }
 
-      const item = getDraggableItem(left + width / 2, top + height / 2);
+  clearTimeout(debounce);
+  debounce = setTimeout(() => {
+    const dropzone = getDropzone(left, top);
 
-      if (isElement(item)) {
-        // draggable 요소의 앞 또는 뒤
-        insertBetweenDraggableItems(item, top);
-      } else {
-        // draggable 요소 사이에 공백이 있어서 draggable item이 안 잡히는 경우 모든 item을 확인
-        const children = dropzone.children;
-        const len = children.length;
+    const item = getDraggableItem(left + width / 2, top + height / 2);
 
-        let i = 0;
-        let child, childRect;
-        if (len < 2) {
-          child = children[i] || null;
-          childRect = child && child.getBoundingClientRect();
-          if (childRect && childRect.top > top) dropzone.prepend(ghostShadow);
-          else dropzone.append(ghostShadow);
-          hideGhost();
-          return;
-        }
+    if (isElement(item)) {
+      // draggable 요소의 앞 또는 뒤
+      insertBetweenDraggableItems(item, top);
+    } else {
+      // draggable 요소 사이에 공백이 있어서 draggable item이 안 잡히는 경우 모든 item을 확인
+      const children = dropzone.children;
+      const len = children.length;
 
-        let nextChild, nextChildRect;
-        for (i = 1; i < len; i++) {
-          child = children[i];
-          childRect = child.getBoundingClientRect();
-          if (childRect.top > top) {
-            dropzone.prepend(ghostShadow);
-            break;
-          }
-
-          nextChild = children[i + 1] || null;
-          nextChildRect = nextChild ? nextChild.getBoundingClientRect() : null;
-          if (!nextChildRect) {
-            dropzone.append(ghostShadow);
-            break;
-          }
-          if (childRect.bottom <= top && nextChildRect.top > top) {
-            insertNodeAfter(ghostShadow, child);
-            break;
-          }
-        }
+      let i = 0;
+      let child, childRect;
+      if (len < 2) {
+        child = children[i] || null;
+        childRect = child && child.getBoundingClientRect();
+        if (childRect && childRect.top > top) dropzone.prepend(ghostShadow);
+        else dropzone.append(ghostShadow);
+        hideGhost();
+        return;
       }
 
-      // drag할 위치가 drag하려는 요소의 원래 위치가 같으면 preview(ghost) 숨김
-      hideGhost();
-    }, 200);
-  }
+      let nextChild, nextChildRect;
+      for (i = 1; i < len; i++) {
+        child = children[i];
+        childRect = child.getBoundingClientRect();
+        if (childRect.top > top) {
+          dropzone.prepend(ghostShadow);
+          break;
+        }
+
+        nextChild = children[i + 1] || null;
+        nextChildRect = nextChild ? nextChild.getBoundingClientRect() : null;
+        if (!nextChildRect) {
+          dropzone.append(ghostShadow);
+          break;
+        }
+        if (childRect.bottom <= top && nextChildRect.top > top) {
+          insertNodeAfter(ghostShadow, child);
+          break;
+        }
+      }
+    }
+
+    // drag할 위치가 drag하려는 요소의 원래 위치가 같으면 preview(ghost) 숨김
+    hideGhost();
+  }, 200);
 }
 
 function hideGhost() {
@@ -169,6 +166,16 @@ function hideGhostShadow() {
   // 한번이라도 dropzone에 append 된 적 있어야 parentNode(dropzone)가 존재
   if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
   ghostShadow.classList.add('dnd-none');
+}
+
+function isConatinGhost() {
+  const {top, left, width, height} = ghost.getBoundingClientRect();
+  const belowGhostTopLeft = getDropzone(left, top);
+  const belowGhostBottomRight = getDropzone(left + width, top + height - 5);
+
+  isContain = isElements(belowGhostTopLeft, belowGhostBottomRight) && belowGhostTopLeft === belowGhostBottomRight;
+
+  return isContain;
 }
 
 function insertBetweenDraggableItems(item, top) {

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -31,6 +31,24 @@ function finish(event) {
   const belowElements = document.elementsFromPoint(clientX, clientY);
   const dropzone = belowElements[1];
   dropzone.appendChild(originElement);
+  /**
+
+    이건 위에 미리 선언해놓고..
+    var event = document.createEvent('Event');
+
+    이건 ie 가 지원 못하는 버전이긴한데, 이걸 써야지 
+    {target : originElement, isContainer: false...} 를 넣을 수 있다. 
+    var event = new CustomEvent('build', { bubbles: true, detail: { name: 'wonhee', value: myTarget.innerText } });
+    
+    event.initEvent('drop', true, true);
+
+    dnd.dropzone(selector); 할 때는 ... 
+    selector 에다가 dropzone을 구분할 수 있는 속성을 넣어놔서 
+    belowElements에서 dropzone을 꺼내야한다.
+
+    꺼낸 dropzone에 이벤트를 발생시킨다.
+    dropzone.dispatchEvent(event);
+   */
   destroy();
 }
 

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -6,6 +6,7 @@ const ERROR_CODE = {
 };
 let originElement = null;
 let ghost = null;
+let ghostShadow = null;
 let ghostWidth, ghostHeight;
 let dropzone = null;
 let isContain = false;
@@ -32,6 +33,7 @@ export async function make(selector) {
 
 async function create() {
   ghost = originElement.cloneNode(true);
+  ghostShadow = originElement.cloneNode(true);
 
   ghost.style.position = 'fixed';
   ghost.style.zIndex = 1000;
@@ -40,6 +42,8 @@ async function create() {
   ghostWidth = width;
   ghostHeight = height;
 
+  ghostShadow.classList.add('dnd-none');
+  ghostShadow.classList.add('dnd-shadow');
   originElement.classList.add('dnd-hidden-origin');
 }
 
@@ -72,7 +76,10 @@ function finish(event) {
 function destroy() {
   originElement.classList.remove('dnd-hidden-origin');
   ghost.parentNode.removeChild(ghost);
+  ghostShadow.parentNode.removeChild(ghostShadow);
+
   ghost = null;
+  ghostShadow = null;
   originElement = null;
   ghostWidth = null;
   ghostHeight = null;
@@ -89,6 +96,14 @@ function setPosition(event) {
   const dropzoneTopLeft = getDropzone(left, top);
   const dropzoneBottomRight = getDropzone(left + ghostWidth, top + ghostHeight);
   isContain = isElement(dropzoneTopLeft) && isElement(dropzoneBottomRight) && dropzoneTopLeft === dropzoneBottomRight;
+
+  if (isContain) {
+    dropzoneTopLeft.appendChild(ghostShadow);
+    ghostShadow.classList.remove('dnd-none');
+  } else {
+    ghostShadow.parentNode.removeChild(ghostShadow);
+    ghostShadow.classList.add('dnd-none');
+  }
 }
 
 function handleMouseUp(event) {

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -48,10 +48,9 @@ function finish(event) {
   if (!isContain) throw Error(ERROR_CODE.E01);
 
   const dropzone = getDropzone(event.clientX, event.clientY);
-  const dropEvent = getDropEvent();
 
   dropzone.replaceChild(originElement, ghostShadow); // ghostShadow를 originElement로 변경
-  dropzone.dispatchEvent(dropEvent);
+  dropzone.fire('drop', {target: originElement, isContain});
 
   destroy(); // ghost 초기화
 }
@@ -205,6 +204,5 @@ function getDraggableItem(x, y) {
   return draggableItem;
 }
 
-const getDropEvent = () => new CustomEvent('drop', {bubbles: false, detail: {target: originElement, isContain}});
 const isOriginElement = (element) => isElement(element) && element.classList.contains('dnd-hidden-origin');
 const clone = (element) => element.cloneNode(true);

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -1,36 +1,72 @@
-import {getElement, isElement, getSize, getPosition} from '@/lib/helper';
+import {getElement, isElement, getSize, getPosition, isElements, insertNodeAfter, insertNodeBefore} from '@/lib/helper';
 import '@/styles/dnd.ghost.scss';
 
 const ERROR_CODE = {
   E01: 'dropzone이 아닙니다.'
 };
-let originElement = null;
-let ghost = null;
-let ghostShadow = null;
-let ghostWidth, ghostHeight;
-let dropzone = null;
-let isContain = false;
+let debounce = null;
 let clickedLeft = 0;
 let clickedTop = 0;
+let originElement = null;
+let ghost = null;
+let ghostWidth = 0;
+let ghostHeight = 0;
+let ghostShadow = null;
+let isContain = false;
 
-export async function make(selector, x, y) {
-  originElement = getElement(selector);
-
-  create(x, y).then(ready);
+export function make(selector, x, y) {
+  create(selector, x, y).then(ready).then(execute);
 }
 
-async function create(x, y) {
+async function create(selector, x, y) {
+  originElement = getElement(selector);
+
   const {top, left} = getPosition(originElement);
   clickedLeft = x - left;
   clickedTop = y - top;
 
-  ghost = originElement.cloneNode(true);
-  ghostShadow = originElement.cloneNode(true);
+  ghost = clone(originElement);
+  ghostShadow = clone(originElement);
 
   initializeGhost();
   initializeGhostShadow();
 
   originElement.classList.add('dnd-hidden-origin');
+}
+
+async function ready() {
+  ghost.addEventListener('mousedown', () => {
+    document.body.append(ghost);
+    ghost.addEventListener('mouseup', handleMouseUp);
+
+    document.addEventListener('mousemove', setPosition);
+  });
+}
+
+export function execute() {
+  ghost.dispatchEvent(new Event('mousedown'));
+}
+
+function finish(event) {
+  if (!isContain) throw Error(ERROR_CODE.E01);
+
+  const dropzone = getDropzone(event.clientX, event.clientY);
+  const dropEvent = getDropEvent();
+
+  dropzone.replaceChild(originElement, ghostShadow); // ghostShadow를 originElement로 변경
+  dropzone.dispatchEvent(dropEvent);
+
+  destroy(); // ghost 초기화
+}
+
+function destroy() {
+  originElement.classList.remove('dnd-hidden-origin');
+  ghost.parentNode.removeChild(ghost);
+  if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
+
+  originElement = null;
+  ghost = null;
+  ghostShadow = null;
 }
 
 function initializeGhost() {
@@ -46,91 +82,82 @@ function initializeGhostShadow() {
   ghostShadow.classList.add('dnd-shadow');
 }
 
-let debounce = null;
+function handleMouseUp(event) {
+  document.removeEventListener('mousemove', setPosition);
+  ghost.removeEventListener('mouseup', handleMouseUp);
 
-function ready() {
-  ghost.addEventListener('mousedown', () => {
-    document.body.append(ghost);
-    document.addEventListener('mousemove', setPosition);
-    ghost.addEventListener('mouseup', handleMouseUp);
-  });
+  try {
+    finish(event);
+  } catch (error) {
+    // dropzone이 아닌 곳에서 mouseup이 발생한 경우 drag 취소
+    if (error.message === ERROR_CODE.E01) destroy();
+  }
 }
 
-export function execute() {
-  ghost.dispatchEvent(new Event('mousedown'));
-}
-
-function finish(event) {
-  if (!isContain) throw Error(ERROR_CODE.E01);
-
-  dropzone = getDropzone(event.clientX, event.clientY);
-
-  const dropEvent = getDropEvent();
-
-  dropzone.dispatchEvent(dropEvent);
-
-  dropzone.replaceChild(originElement, ghostShadow);
-
-  destroy();
-}
-
-function destroy() {
-  originElement.classList.remove('dnd-hidden-origin');
-  ghost.parentNode.removeChild(ghost);
-  if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
-
-  ghost = null;
-  ghostShadow = null;
-  originElement = null;
-  ghostWidth = null;
-  ghostHeight = null;
-}
-
-function insertAfter(newNode, referenceNode) {
-  referenceNode.parentNode.insertBefore(newNode, referenceNode.nextElementSibling);
-}
 function setPosition(event) {
   const {pageX, pageY} = event;
   ghost.style.left = `${pageX - clickedLeft}px`;
   ghost.style.top = `${pageY - clickedTop}px`;
 
   const {top, left} = getPosition(ghost);
-  const dropzoneTopLeft = getDropzone(left, top);
-  const dropzoneBottomRight = getDropzone(left + ghostWidth, top + ghostHeight - 5);
-  isContain = isElement(dropzoneTopLeft) && isElement(dropzoneBottomRight) && dropzoneTopLeft === dropzoneBottomRight;
+  const belowGhostTopLeft = getDropzone(left, top);
+  const belowGhostBottomRight = getDropzone(left + ghostWidth, top + ghostHeight - 5);
 
-  if (isContain) {
-    clearTimeout(debounce);
-    debounce = setTimeout(() => {
-      const draggableItem = getDraggableItem(left + ghostWidth / 2, top + ghostHeight / 2);
-      if (isElement(draggableItem)) {
-        const draggableItemTop = getPosition(draggableItem).top;
-        if (draggableItemTop <= top) insertAfter(ghostShadow, draggableItem);
-        else dropzoneTopLeft.insertBefore(ghostShadow, draggableItem);
-      } else {
-        const dropzonePosition = getPosition(dropzoneTopLeft);
-        const dropzoneTop = dropzonePosition.top;
-        const dropzoneBottom = dropzonePosition.top + getSize(dropzoneTopLeft).height;
-        if (Math.abs(dropzoneTop - top) < Math.abs(dropzoneBottom - top)) dropzoneTopLeft.prepend(ghostShadow);
-        else dropzoneTopLeft.append(ghostShadow);
-      }
-    }, 200);
-    ghostShadow.classList.remove('dnd-none');
-  } else {
-    // 한번이라도 append 된 적 있어야 parentNode가 존재
+  isContain = isElements(belowGhostTopLeft, belowGhostBottomRight) && belowGhostTopLeft === belowGhostBottomRight;
+
+  if (!isContain) {
+    // 한번이라도 dropzone에 append 된 적 있어야 parentNode(dropzone)가 존재
     if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
     ghostShadow.classList.add('dnd-none');
+  } else {
+    const dropzone = belowGhostTopLeft;
+
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      const item = getDraggableItem(left + ghostWidth / 2, top + ghostHeight / 2);
+
+      if (isElement(item)) {
+        // draggable 요소의 앞 또는 뒤
+        insertBetweenDraggableItems(item, top);
+      } else {
+        // dropzone 내에서의 맨 앞 또는 뒤
+        insertIntoDropzone(dropzone, top);
+      }
+
+      // drag할 위치가 drag하려는 요소의 원래 위치가 같으면 preview(ghost) 숨김
+      hideGhost();
+    }, 200);
   }
 }
 
-function handleMouseUp(event) {
-  document.removeEventListener('mousemove', setPosition);
-  ghost.removeEventListener('mouseup', handleMouseUp);
-  try {
-    finish(event);
-  } catch (error) {
-    // console.log(error);
-    if (error.message === ERROR_CODE.E01) destroy();
+function hideGhost() {
+  const {nextElementSibling, previousElementSibling, classList} = ghostShadow;
+
+  if (!isOriginElement(nextElementSibling) && !isOriginElement(previousElementSibling)) {
+    classList.remove('dnd-none');
+  } else {
+    if (!classList.contains('dnd-none')) classList.add('dnd-none');
+  }
+}
+
+function insertBetweenDraggableItems(item, top) {
+  const itemTop = getPosition(item).top;
+
+  if (itemTop <= top) {
+    insertNodeAfter(ghostShadow, item);
+  } else {
+    insertNodeBefore(ghostShadow, item);
+  }
+}
+
+function insertIntoDropzone(dropzone, top) {
+  const dropzoneTop = getPosition(dropzone).top;
+  const dropzoneBottom = dropzoneTop + getSize(dropzone).height;
+
+  if (Math.abs(dropzoneTop - top) < Math.abs(dropzoneBottom - top)) {
+    dropzone.prepend(ghostShadow);
+  } else {
+    dropzone.append(ghostShadow);
   }
 }
 
@@ -140,15 +167,24 @@ function getDropzone(x, y) {
 
   return dropzone;
 }
+
 function getDraggableItem(x, y) {
   const belowElements = document.elementsFromPoint(x, y);
-  const dropzone = belowElements
-    .slice(1)
-    .find((el) => el.getAttribute('dnd-draggable') === 'true' && el !== ghostShadow);
+  const draggableItem = belowElements.find(
+    (el) => el.getAttribute('dnd-draggable') === 'true' && el !== ghostShadow && el !== ghost
+  );
 
-  return dropzone;
+  return draggableItem;
 }
 
 function getDropEvent() {
   return new CustomEvent('drop', {bubbles: false, detail: {target: originElement, isContain}});
+}
+
+function isOriginElement(element) {
+  return isElement(element) && element.classList.contains('dnd-hidden-origin');
+}
+
+function clone(element) {
+  return element.cloneNode(true);
 }

--- a/src/lib/dnd.ghost.js
+++ b/src/lib/dnd.ghost.js
@@ -100,9 +100,7 @@ function setPosition(event) {
   isContain = isElements(belowGhostTopLeft, belowGhostBottomRight) && belowGhostTopLeft === belowGhostBottomRight;
 
   if (!isContain) {
-    // 한번이라도 dropzone에 append 된 적 있어야 parentNode(dropzone)가 존재
-    if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
-    ghostShadow.classList.add('dnd-none');
+    hideGhostShadow();
   } else {
     clearTimeout(debounce);
     debounce = setTimeout(() => {
@@ -165,6 +163,12 @@ function hideGhost() {
   } else {
     if (!classList.contains('dnd-none')) classList.add('dnd-none');
   }
+}
+
+function hideGhostShadow() {
+  // 한번이라도 dropzone에 append 된 적 있어야 parentNode(dropzone)가 존재
+  if (isElement(ghostShadow.parentNode)) ghostShadow.parentNode.removeChild(ghostShadow);
+  ghostShadow.classList.add('dnd-none');
 }
 
 function insertBetweenDraggableItems(item, top) {

--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -1,28 +1,14 @@
-import {getElement} from '@/lib/helper';
+import {getElement, isString, isEmptyString} from '@/lib/helper';
 import * as domutil from '@/lib/domutil';
 import * as ghost from '@/lib/dnd.ghost';
-/*
-<div id="dnd1"></div>
-<div id="dnd2"></div>
-<div class="my-dnd"></div>
-<div class="my-dnd"></div>
-<div id="drop1"></div>
-<div id="drop2"></div>
-(function() {
-    dnd.draggable('#dnd1');
-    dnd.draggable('.my-dnd');    // 2개 엘리먼트 처리
-    var dropzone1 = dnd.dropzone('#drop1');    // Dropzone은 인스턴스를 반환하고 한번에 하나의 dropzone을 생성할 수 있다.
-    var dropzone2 = dnd.dropzone('#drop2');
-    
-    dropzone1.on('drop', function(eventData) {
-        console.log(eventData.target);    // 드롭 된 엘리먼트
-        console.log(eventData.isContain);    // 완전 포함 여부
-    });
-})();
-*/
 
 const dnd = {
   draggable(selector) {
+    const dropzoneAttr = selector.getAttribute('dropzone');
+    if (isString(dropzoneAttr) && !isEmptyString(dropzoneAttr)) {
+      throw Error('dropzone 요소에는 draggable을 설정할 수 없습니다.');
+    }
+
     selector.setAttribute('dnd-draggable', true);
     domutil.on(selector, 'mousedown', (e) => {
       ghost.make(selector, e.pageX, e.pageY);
@@ -30,6 +16,11 @@ const dnd = {
   },
   dropzone(selector) {
     const element = getElement(selector);
+
+    const draggableAttr = element.getAttribute('dnd-draggable');
+    if (isString(draggableAttr) && !isEmptyString(draggableAttr)) {
+      throw Error('draggable 요소에는 dropzone을 설정할 수 없습니다.');
+    }
 
     element.setAttribute('dropzone', true);
 

--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -1,0 +1,32 @@
+import * as domutil from '@/lib/domutil';
+import * as ghost from '@/lib/dnd.ghost';
+/*
+<div id="dnd1"></div>
+<div id="dnd2"></div>
+<div class="my-dnd"></div>
+<div class="my-dnd"></div>
+<div id="drop1"></div>
+<div id="drop2"></div>
+(function() {
+    dnd.draggable('#dnd1');
+    dnd.draggable('.my-dnd');    // 2개 엘리먼트 처리
+    var dropzone1 = dnd.dropzone('#drop1');    // Dropzone은 인스턴스를 반환하고 한번에 하나의 dropzone을 생성할 수 있다.
+    var dropzone2 = dnd.dropzone('#drop2');
+    
+    dropzone1.on('drop', function(eventData) {
+        console.log(eventData.target);    // 드롭 된 엘리먼트
+        console.log(eventData.isContain);    // 완전 포함 여부
+    });
+})();
+*/
+
+const dnd = {
+  draggable(selector) {
+    domutil.on(selector, 'mousedown', () => {
+      ghost.make(selector).then(ghost.execute);
+    });
+  },
+  dropzone(selector) {}
+};
+
+export default dnd;

--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -23,6 +23,7 @@ import * as ghost from '@/lib/dnd.ghost';
 
 const dnd = {
   draggable(selector) {
+    selector.setAttribute('dnd-draggable', true);
     domutil.on(selector, 'mousedown', (e) => {
       ghost.make(selector, e.pageX, e.pageY).then(ghost.execute);
     });

--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -23,8 +23,8 @@ import * as ghost from '@/lib/dnd.ghost';
 
 const dnd = {
   draggable(selector) {
-    domutil.on(selector, 'mousedown', () => {
-      ghost.make(selector).then(ghost.execute);
+    domutil.on(selector, 'mousedown', (e) => {
+      ghost.make(selector, e.pageX, e.pageY).then(ghost.execute);
     });
   },
   dropzone(selector) {

--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -1,3 +1,4 @@
+import {getElement} from '@/lib/helper';
 import * as domutil from '@/lib/domutil';
 import * as ghost from '@/lib/dnd.ghost';
 /*
@@ -26,7 +27,13 @@ const dnd = {
       ghost.make(selector).then(ghost.execute);
     });
   },
-  dropzone(selector) {}
+  dropzone(selector) {
+    const element = getElement(selector);
+
+    element.setAttribute('dropzone', true);
+
+    return element;
+  }
 };
 
 export default dnd;

--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -1,5 +1,6 @@
 import {getElement, isString, isEmptyString} from '@/lib/helper';
 import * as domutil from '@/lib/domutil';
+import CustomEvents from '@/lib/CustomEvents';
 import * as ghost from '@/lib/dnd.ghost';
 
 const dnd = {
@@ -23,6 +24,7 @@ const dnd = {
     }
 
     element.setAttribute('dropzone', true);
+    CustomEvents.mixin(element);
 
     return element;
   }

--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -25,7 +25,7 @@ const dnd = {
   draggable(selector) {
     selector.setAttribute('dnd-draggable', true);
     domutil.on(selector, 'mousedown', (e) => {
-      ghost.make(selector, e.pageX, e.pageY).then(ghost.execute);
+      ghost.make(selector, e.pageX, e.pageY);
     });
   },
   dropzone(selector) {

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -13,7 +13,12 @@ export const getElement = (selector) => {
 
 export const getSize = ({offsetWidth, offsetHeight}) => ({width: offsetWidth, height: offsetHeight});
 export const getPosition = ({offsetTop, offsetLeft}) => ({top: offsetTop, left: offsetLeft});
+export const insertNodeAfter = (newNode, referenceNode) =>
+  referenceNode.parentNode.insertBefore(newNode, referenceNode.nextElementSibling);
+export const insertNodeBefore = (newNode, referenceNode) =>
+  referenceNode.parentNode.insertBefore(newNode, referenceNode);
 export const isElement = (v) => v instanceof Element;
+export const isElements = (...args) => args.every((v) => v instanceof Element);
 export const isWindow = (v) => v === window;
 export const isString = (v) => typeof v === 'string';
 export const isEmptyString = (v) => v === '';

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -10,6 +10,9 @@ export const getElement = (selector) => {
 
   return element;
 };
+
+export const getSize = ({offsetWidth, offsetHeight}) => ({width: offsetWidth, height: offsetHeight});
+export const getPosition = ({offsetTop, offsetLeft}) => ({top: offsetTop, left: offsetLeft});
 export const isElement = (v) => v instanceof Element;
 export const isWindow = (v) => v === window;
 export const isString = (v) => typeof v === 'string';

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -11,8 +11,6 @@ export const getElement = (selector) => {
   return element;
 };
 
-export const getSize = ({offsetWidth, offsetHeight}) => ({width: offsetWidth, height: offsetHeight});
-export const getPosition = ({offsetTop, offsetLeft}) => ({top: offsetTop, left: offsetLeft});
 export const insertNodeAfter = (newNode, referenceNode) =>
   referenceNode.parentNode.insertBefore(newNode, referenceNode.nextElementSibling);
 export const insertNodeBefore = (newNode, referenceNode) =>

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -23,3 +23,11 @@ export const isEmptyString = (v) => v === '';
 export const isFunction = (v) => typeof v === 'function';
 export const isObject = (v) => Object.prototype.toString.call(v) === '[object Object]';
 export const isNull = (v) => v === null;
+export const debounce = (fn, time) => {
+  let timer;
+  return function () {
+    const args = arguments;
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(args), time);
+  };
+};

--- a/src/styles/dnd.ghost.scss
+++ b/src/styles/dnd.ghost.scss
@@ -1,0 +1,3 @@
+.dnd-hidden-origin {
+  visibility: hidden;
+}

--- a/src/styles/dnd.ghost.scss
+++ b/src/styles/dnd.ghost.scss
@@ -1,3 +1,10 @@
 .dnd-hidden-origin {
   visibility: hidden;
 }
+.dnd-none {
+  display: none;
+}
+.dnd-shadow {
+  z-index: 0;
+  opacity: 0.7 !important;
+}

--- a/src/styles/dnd.ghost.scss
+++ b/src/styles/dnd.ghost.scss
@@ -1,5 +1,5 @@
 .dnd-hidden-origin {
-  visibility: hidden;
+  opacity: 0.7;
 }
 .dnd-none {
   display: none;

--- a/src/styles/dnd.ghost.scss
+++ b/src/styles/dnd.ghost.scss
@@ -8,3 +8,8 @@
   z-index: 0;
   opacity: 0.7 !important;
 }
+.dnd-ghost {
+  position: fixed;
+  z-index: 1000;
+  border: 1px solid blue;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,13 +1,13 @@
 .list {
-  padding: 10px;
+  padding: 30px;
   background-color: #d6d4d4;
   width: 500px;
-  min-height: 50px;
+  min-height: 110px;
   height: auto;
 }
 .item {
   margin-bottom: 10px;
   background-color: cornflowerblue;
   width: 480px;
-  height: 30px;
+  height: 50px;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,13 @@
+.list {
+  padding: 10px;
+  background-color: #d6d4d4;
+  width: 500px;
+  min-height: 50px;
+  height: auto;
+}
+.item {
+  margin-bottom: 10px;
+  background-color: cornflowerblue;
+  width: 480px;
+  height: 30px;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,13 +1,21 @@
 .list {
   padding: 30px;
   background-color: #d6d4d4;
-  width: 500px;
+  width: 300px;
   min-height: 110px;
   height: auto;
+}
+.list2 {
+  padding: 30px;
+  background-color: #d6d4d4;
+  width: 300px;
+  min-height: 110px;
+  height: auto;
+  margin-left: 20px;
 }
 .item {
   margin-bottom: 10px;
   background-color: cornflowerblue;
-  width: 480px;
+  width: 280px;
   height: 50px;
 }

--- a/src/styles/sample.scss
+++ b/src/styles/sample.scss
@@ -1,3 +1,0 @@
-body {
-  background-color: pink;
-}


### PR DESCRIPTION
## 요구 사항
- 선행으로 직접 개발한 커스텀 이벤트 관리 유틸리티를 사용한다.
- 특정 DOM엘리먼트에 사용해 Drag & Drop기능을 부여하는 라이브러리
- 특정 DOM엘리먼트에 사용해 Dropzone으로 설정할 수 있는 기능.
- 하나의 DOM엘리먼가 Drag & Drop, Dropzone 두 기능을 적용할 수 있다.
- 같은 기능을 두 번 이상 적용할 수 없다 (Drag & Drop을 같은 엘리먼트에 적용 불가 처리)
- 엘리먼트가 Dropzone에 드롭되면 커스텀 이벤트가 발생한다.
- Drag가능 엘리먼트와 Dropzone은 동적으로 추가/제거가 가능해야 한다.
- (option) Dropzone에 드롭될 때 커스텀 이벤트에 겹친 상태인지 완전히 포함된 상태인지 데이터를 제공한다.

## 구현 기능
- 요구 사항 기능 전체 (option 포함)
- 드래그 시 드롭 가능한 위치면 드롭된 요소를 미리 보여주는 기능
- 드래그 시 드롭 전까지는 기존 요소를 원래 위치에 그대로 유지해주는 기능
- dropzone 외의 영역 또는 dropzone에 완전히 포함되지 않는 위치에 드롭 시 드래그하고 있던 요소는 원래 위치로 돌아가는 기능

## 미구현 사항
- TC 작성 X

## 실행
```terminal
npm i
npm start
```

## 실행 결과
![dnd-sample](https://user-images.githubusercontent.com/17108742/98466116-cda69680-2210-11eb-84c5-c6087e04cea9.gif)


## 참고 링크
- https://kutlugsahin.github.io/smooth-dnd-demo/
- https://github.com/bevacqua/dragula
- https://javascript.info/mouse-drag-and-drop